### PR TITLE
Change the way statics work to avoid RXCPP_SELECT_ANY

### DIFF
--- a/Rx/v2/src/rxcpp/rx-notification.hpp
+++ b/Rx/v2/src/rxcpp/rx-notification.hpp
@@ -205,47 +205,24 @@ private:
         return std::make_shared<on_error_notification>(ep);
     }
 
-    struct on_next_factory
-    {
-        type operator()(T value) const {
-            return std::make_shared<on_next_notification>(std::move(value));
-        }
-    };
-
-    struct on_completed_factory
-    {
-        type operator()() const {
-            return std::make_shared<on_completed_notification>();
-        }
-    };
-
-    struct on_error_factory
-    {
-        template<typename Exception>
-        type operator()(Exception&& e) const {
-            return make_on_error(typename std::conditional<
-                std::is_same<typename std::decay<Exception>::type, std::exception_ptr>::value,
-                    exception_ptr_tag, exception_tag>::type(),
-                std::forward<Exception>(e));
-        }
-    };
 public:
-    const static on_next_factory on_next;
-    const static on_completed_factory on_completed;
-    const static on_error_factory on_error;
+    template<typename U>
+    static type on_next(U value) {
+        return std::make_shared<on_next_notification>(std::move(value));
+    }
+
+    static type on_completed() {
+        return std::make_shared<on_completed_notification>();
+    }
+
+    template<typename Exception>
+    static type on_error(Exception&& e) {
+        return make_on_error(typename std::conditional<
+            std::is_same<typename std::decay<Exception>::type, std::exception_ptr>::value,
+                exception_ptr_tag, exception_tag>::type(),
+            std::forward<Exception>(e));
+    }
 };
-
-template<class T>
-//static
-RXCPP_SELECT_ANY const typename notification<T>::on_next_factory notification<T>::on_next = notification<T>::on_next_factory();
-
-template<class T>
-//static
-RXCPP_SELECT_ANY const typename notification<T>::on_completed_factory notification<T>::on_completed = notification<T>::on_completed_factory();
-
-template<class T>
-//static
-RXCPP_SELECT_ANY const typename notification<T>::on_error_factory notification<T>::on_error = notification<T>::on_error_factory();
 
 template<class T>
 bool operator == (const std::shared_ptr<detail::notification_base<T>>& lhs, const std::shared_ptr<detail::notification_base<T>>& rhs) {

--- a/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -25,6 +25,11 @@ typedef std::shared_ptr<const worker_interface> const_worker_interface_ptr;
 typedef std::shared_ptr<scheduler_interface> scheduler_interface_ptr;
 typedef std::shared_ptr<const scheduler_interface> const_scheduler_interface_ptr;
 
+inline action_ptr shared_empty() {
+    static action_ptr shared_empty = std::make_shared<detail::action_type>();
+    return shared_empty;
+}
+
 }
 
 // It is essential to keep virtual function calls out of an inner loop.
@@ -123,7 +128,6 @@ class action : public action_base
 {
     typedef action this_type;
     detail::action_ptr inner;
-    static detail::action_ptr shared_empty;
 public:
     action()
     {
@@ -135,7 +139,7 @@ public:
 
     /// return the empty action
     inline static action empty() {
-        return action(shared_empty);
+        return action(detail::shared_empty());
     }
 
     /// call the function
@@ -639,10 +643,6 @@ public:
 inline void action::operator()(const schedulable& s, const recurse& r) const {
     (*inner)(s, r);
 }
-
-//static
-RXCPP_SELECT_ANY detail::action_ptr action::shared_empty = detail::action_ptr(new detail::action_type());
-
 
 inline action make_action_empty() {
     return action::empty();

--- a/Rx/v2/src/rxcpp/rx-subscription.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscription.hpp
@@ -210,6 +210,8 @@ auto make_subscription(Unsubscribe&& u)
     return  subscription(static_subscription<Unsubscribe>(std::forward<Unsubscribe>(u)));
 }
 
+class composite_subscription;
+
 namespace detail {
 
 struct tag_composite_subscription_empty {};
@@ -348,6 +350,8 @@ public:
     }
 };
 
+inline composite_subscription shared_empty();
+
 }
 
 class composite_subscription
@@ -357,8 +361,6 @@ class composite_subscription
     typedef detail::composite_subscription_inner inner_type;
 public:
     typedef subscription::weak_state_type weak_subscription;
-
-    static composite_subscription shared_empty;
 
     composite_subscription(detail::tag_composite_subscription_empty et)
         : inner_type(et)
@@ -393,7 +395,7 @@ public:
     }
 
     static inline composite_subscription empty() {
-        return shared_empty;
+        return detail::shared_empty();
     }
 
     using subscription::is_subscribed;
@@ -438,9 +440,14 @@ inline bool operator!=(const composite_subscription& lhs, const composite_subscr
     return !(lhs == rhs);
 }
 
-//static
-RXCPP_SELECT_ANY composite_subscription composite_subscription::shared_empty = composite_subscription(detail::tag_composite_subscription_empty());
+namespace detail {
 
+inline composite_subscription shared_empty() {
+    static composite_subscription shared_empty = composite_subscription(tag_composite_subscription_empty());
+    return shared_empty;
+}
+
+}
 
 template<class T>
 class resource : public subscription_base

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -15,14 +15,6 @@
 #endif
 #endif
 
-#if !defined(RXCPP_SELECT_ANY)
-#if defined(_MSC_VER)
-#define RXCPP_SELECT_ANY __declspec(selectany)
-#else
-#define RXCPP_SELECT_ANY __attribute__((weak))
-#endif
-#endif
-
 #if !defined(RXCPP_DELETE)
 #if defined(_MSC_VER)
 #define RXCPP_DELETE __pragma(warning(disable: 4822)) =delete

--- a/Rx/v2/src/rxcpp/schedulers/rx-currentthread.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-currentthread.hpp
@@ -248,14 +248,11 @@ public:
     virtual worker create_worker(composite_subscription cs) const {
         return worker(std::move(cs), wi);
     }
-    const static scheduler instance;
 };
 
-//static
-RXCPP_SELECT_ANY const scheduler current_thread::instance = make_scheduler<current_thread>();
-
 inline const scheduler& make_current_thread() {
-    return current_thread::instance;
+    static scheduler instance = make_scheduler<current_thread>();
+    return instance;
 }
 
 }

--- a/Rx/v2/src/rxcpp/schedulers/rx-eventloop.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-eventloop.hpp
@@ -93,14 +93,11 @@ public:
     virtual worker create_worker(composite_subscription cs) const {
         return worker(cs, std::shared_ptr<loop_worker>(new loop_worker(cs, loops[++count % loops.size()])));
     }
-    const static scheduler instance;
 };
 
-//static
-RXCPP_SELECT_ANY const scheduler event_loop::instance = make_scheduler<event_loop>();
-
 inline scheduler make_event_loop() {
-    return event_loop::instance;
+    static scheduler instance = make_scheduler<event_loop>();
+    return instance;
 }
 inline scheduler make_event_loop(thread_factory tf) {
     return make_scheduler<event_loop>(tf);

--- a/Rx/v2/src/rxcpp/schedulers/rx-immediate.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-immediate.hpp
@@ -70,14 +70,11 @@ public:
     virtual worker create_worker(composite_subscription cs) const {
         return worker(std::move(cs), wi);
     }
-    const static scheduler instance;
 };
 
-//static
-RXCPP_SELECT_ANY const scheduler immediate::instance = make_scheduler<immediate>();
-
 inline const scheduler& make_immediate() {
-    return immediate::instance;
+    static scheduler instance = make_scheduler<immediate>();
+    return instance;
 }
 
 }

--- a/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp
@@ -162,15 +162,11 @@ public:
     virtual worker create_worker(composite_subscription cs) const {
         return worker(cs, std::shared_ptr<new_worker>(new new_worker(cs, factory)));
     }
-
-    const static scheduler instance;
 };
 
-//static
-RXCPP_SELECT_ANY const scheduler new_thread::instance = make_scheduler<new_thread>();
-
 inline scheduler make_new_thread() {
-    return new_thread::instance;
+    static scheduler instance = make_scheduler<new_thread>();
+    return instance;
 }
 inline scheduler make_new_thread(thread_factory tf) {
     return make_scheduler<new_thread>(tf);

--- a/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
@@ -378,37 +378,23 @@ public:
 
         messages() {}
 
-        struct on_next_factory
-        {
-            recorded_type operator()(long ticks, T value) const {
-                return recorded_type(ticks, notification_type::on_next(value));
-            }
-        };
-        struct on_completed_factory
-        {
-            recorded_type operator()(long ticks) const {
-                return recorded_type(ticks, notification_type::on_completed());
-            }
-        };
-        struct on_error_factory
-        {
-            template<class Exception>
-            recorded_type operator()(long ticks, Exception&& e) const {
-                return recorded_type(ticks, notification_type::on_error(std::forward<Exception>(e)));
-            }
-        };
+        template<typename U>
+        static recorded_type next(long ticks, U value) {
+            return recorded_type(ticks, notification_type::on_next(std::move(value)));
+        }
 
-        static const on_next_factory next;
-        static const on_completed_factory completed;
-        static const on_error_factory error;
+        static recorded_type completed(long ticks) {
+            return recorded_type(ticks, notification_type::on_completed());
+        }
 
-        struct subscribe_factory
-        {
-            rxn::subscription operator()(long subscribe, long unsubscribe) const {
-                return rxn::subscription(subscribe, unsubscribe);
-            }
-        };
-        static const subscribe_factory subscribe;
+        template<typename Exception>
+        static recorded_type error(long ticks, Exception&& e) {
+            return recorded_type(ticks, notification_type::on_error(std::forward<Exception>(e)));
+        }
+
+        static rxn::subscription subscribe(long subscribe, long unsubscribe) {
+            return rxn::subscription(subscribe, unsubscribe);
+        }
     };
 
     class test_worker : public worker
@@ -584,23 +570,6 @@ public:
         return      tester->make_cold_observable(std::vector<T>(il));
     }
 };
-
-template<class T>
-//static
-RXCPP_SELECT_ANY const typename test::messages<T>::on_next_factory test::messages<T>::next = test::messages<T>::on_next_factory();
-
-template<class T>
-//static
-RXCPP_SELECT_ANY const typename test::messages<T>::on_completed_factory test::messages<T>::completed = test::messages<T>::on_completed_factory();
-
-template<class T>
-//static
-RXCPP_SELECT_ANY const typename test::messages<T>::on_error_factory test::messages<T>::error = test::messages<T>::on_error_factory();
-
-template<class T>
-//static
-RXCPP_SELECT_ANY const typename test::messages<T>::subscribe_factory test::messages<T>::subscribe = test::messages<T>::subscribe_factory();
-
 
 
 inline test make_test() {


### PR DESCRIPTION
clang-3.6 wouldn't link, it had lots of errors like:
```
`.text.startup' referenced in section `.text.startup' of CMakeFiles/rxcppv2_test.dir/RxCpp/Rx/v2/test/subscriptions/subscription.cpp.o: defined in discarded section `.text.startup[_ZN5rxcpp22composite_subscription12shared_emptyE]' of CMakeFiles/rxcppv2_test.dir/RxCpp/Rx/v2/test/subscriptions/subscription.cpp.o 
```