### PR TITLE
schedule observer and subscription in buffer and window when using time

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-window_time.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_time.hpp
@@ -51,14 +51,16 @@ struct window_with_time
 
         struct window_with_time_subscriber_values : public window_with_time_values
         {
-            window_with_time_subscriber_values(dest_type d, window_with_time_values v, coordinator_type c)
+            window_with_time_subscriber_values(composite_subscription cs, dest_type d, window_with_time_values v, coordinator_type c)
                 : window_with_time_values(v)
+                , cs(std::move(cs))
                 , dest(std::move(d))
                 , coordinator(std::move(c))
                 , worker(std::move(coordinator.get_worker()))
                 , expected(worker.now())
             {
             }
+            composite_subscription cs;
             dest_type dest;
             coordinator_type coordinator;
             rxsc::worker worker;
@@ -67,54 +69,129 @@ struct window_with_time
         };
         std::shared_ptr<window_with_time_subscriber_values> state;
 
-        window_with_time_observer(dest_type d, window_with_time_values v, coordinator_type c)
-            : state(std::make_shared<window_with_time_subscriber_values>(window_with_time_subscriber_values(std::move(d), v, std::move(c))))
+        window_with_time_observer(composite_subscription cs, dest_type d, window_with_time_values v, coordinator_type c)
+            : state(std::make_shared<window_with_time_subscriber_values>(window_with_time_subscriber_values(std::move(cs), std::move(d), v, std::move(c))))
         {
             auto localState = state;
-            auto release_window = [localState](const rxsc::schedulable&) {
-                localState->subj[0].get_subscriber().on_completed();
-                localState->subj.pop_front();
+
+            auto disposer = [=](const rxsc::schedulable&){
+                localState->cs.unsubscribe();
+                localState->dest.unsubscribe();
+                localState->worker.unsubscribe();
             };
-            auto create_window = [localState, release_window](const rxsc::schedulable&) {
+            auto selectedDisposer = on_exception(
+                [&](){return localState->coordinator.act(disposer);},
+                localState->dest);
+            if (selectedDisposer.empty()) {
+                return;
+            }
+
+            localState->dest.add([=](){
+                localState->worker.schedule(selectedDisposer.get());
+            });
+            localState->cs.add([=](){
+                localState->worker.schedule(selectedDisposer.get());
+            });
+
+            //
+            // The scheduler is FIFO for any time T. Since the observer is scheduling
+            // on_next/on_error/oncompleted the timed schedule calls must be resheduled
+            // when they occur to ensure that production happens after on_next/on_error/oncompleted
+            //
+
+            auto release_window = [localState](const rxsc::schedulable&) {
+                localState->worker.schedule([localState](const rxsc::schedulable&) {
+                    localState->subj[0].get_subscriber().on_completed();
+                    localState->subj.pop_front();
+                });
+            };
+            auto selectedRelease = on_exception(
+                [&](){return localState->coordinator.act(release_window);},
+                localState->dest);
+            if (selectedRelease.empty()) {
+                return;
+            }
+
+            auto create_window = [localState, selectedRelease](const rxsc::schedulable&) {
                 localState->subj.push_back(rxcpp::subjects::subject<T>());
                 localState->dest.on_next(localState->subj[localState->subj.size() - 1].get_observable().as_dynamic());
 
                 auto produce_at = localState->expected + localState->period;
                 localState->expected += localState->skip;
-                localState->worker.schedule(produce_at, release_window);
+                localState->worker.schedule(produce_at, [localState, selectedRelease](const rxsc::schedulable&) {
+                    localState->worker.schedule(selectedRelease.get());
+                });
             };
+            auto selectedCreate = on_exception(
+                [&](){return localState->coordinator.act(create_window);},
+                localState->dest);
+            if (selectedCreate.empty()) {
+                return;
+            }
 
             state->worker.schedule_periodically(
                 state->expected,
                 state->skip,
-                create_window);
+                [localState, selectedCreate](const rxsc::schedulable&) {
+                    localState->worker.schedule(selectedCreate.get());
+                });
         }
 
         void on_next(T v) const {
-            for (auto s : state->subj) {
-                s.get_subscriber().on_next(v);
+            auto localState = state;
+            auto work = [v, localState](const rxsc::schedulable&){
+                for (auto s : localState->subj) {
+                    s.get_subscriber().on_next(v);
+                }
+            };
+            auto selectedWork = on_exception(
+                [&](){return localState->coordinator.act(work);},
+                localState->dest);
+            if (selectedWork.empty()) {
+                return;
             }
+            localState->worker.schedule(selectedWork.get());
         }
 
         void on_error(std::exception_ptr e) const {
-            for (auto s : state->subj) {
-                s.get_subscriber().on_error(e);
+            auto localState = state;
+            auto work = [e, localState](const rxsc::schedulable&){
+                for (auto s : localState->subj) {
+                    s.get_subscriber().on_error(e);
+                }
+                localState->dest.on_error(e);
+            };
+            auto selectedWork = on_exception(
+                [&](){return localState->coordinator.act(work);},
+                localState->dest);
+            if (selectedWork.empty()) {
+                return;
             }
-            state->dest.on_error(e);
+            localState->worker.schedule(selectedWork.get());
         }
 
         void on_completed() const {
-            for (auto s : state->subj) {
-                s.get_subscriber().on_completed();
+            auto localState = state;
+            auto work = [localState](const rxsc::schedulable&){
+                for (auto s : localState->subj) {
+                    s.get_subscriber().on_completed();
+                }
+                localState->dest.on_completed();
+            };
+            auto selectedWork = on_exception(
+                [&](){return localState->coordinator.act(work);},
+                localState->dest);
+            if (selectedWork.empty()) {
+                return;
             }
-            state->dest.on_completed();
+            localState->worker.schedule(selectedWork.get());
         }
 
         static subscriber<T, observer_type> make(dest_type d, window_with_time_values v) {
-            auto cs = d.get_subscription();
-            auto coordinator = v.coordination.create_coordinator(cs);
+            auto cs = composite_subscription();
+            auto coordinator = v.coordination.create_coordinator();
 
-            return make_subscriber<T>(std::move(cs), observer_type(this_type(std::move(d), std::move(v), std::move(coordinator))));
+            return make_subscriber<T>(cs, observer_type(this_type(cs, std::move(d), std::move(v), std::move(coordinator))));
         }
     };
 

--- a/Rx/v2/src/rxcpp/operators/rx-window_time_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_time_count.hpp
@@ -51,8 +51,9 @@ struct window_with_time_or_count
 
         struct window_with_time_or_count_subscriber_values : public window_with_time_or_count_values
         {
-            window_with_time_or_count_subscriber_values(dest_type d, window_with_time_or_count_values v, coordinator_type c)
+            window_with_time_or_count_subscriber_values(composite_subscription cs, dest_type d, window_with_time_or_count_values v, coordinator_type c)
                 : window_with_time_or_count_values(std::move(v))
+                , cs(std::move(cs))
                 , dest(std::move(d))
                 , coordinator(std::move(c))
                 , worker(std::move(coordinator.get_worker()))
@@ -60,6 +61,7 @@ struct window_with_time_or_count
                 , subj_id(0)
             {
             }
+            composite_subscription cs;
             dest_type dest;
             coordinator_type coordinator;
             rxsc::worker worker;
@@ -70,56 +72,120 @@ struct window_with_time_or_count
         typedef std::shared_ptr<window_with_time_or_count_subscriber_values> state_type;
         state_type state;
 
-        window_with_time_or_count_observer(dest_type d, window_with_time_or_count_values v, coordinator_type c)
-            : state(std::make_shared<window_with_time_or_count_subscriber_values>(window_with_time_or_count_subscriber_values(std::move(d), std::move(v), std::move(c))))
+        window_with_time_or_count_observer(composite_subscription cs, dest_type d, window_with_time_or_count_values v, coordinator_type c)
+            : state(std::make_shared<window_with_time_or_count_subscriber_values>(window_with_time_or_count_subscriber_values(std::move(cs), std::move(d), std::move(v), std::move(c))))
         {
-            state->dest.on_next(state->subj.get_observable().as_dynamic());
             auto new_id = state->subj_id;
-            auto produce_time = state->worker.now() + state->period;
+            auto produce_time = state->worker.now();
             auto localState = state;
-            state->worker.schedule(produce_time, [new_id, produce_time, localState](const rxsc::schedulable&){
-                release_window(new_id, produce_time, localState);
+
+            auto disposer = [=](const rxsc::schedulable&){
+                localState->cs.unsubscribe();
+                localState->dest.unsubscribe();
+                localState->worker.unsubscribe();
+            };
+            auto selectedDisposer = on_exception(
+                [&](){return localState->coordinator.act(disposer);},
+                localState->dest);
+            if (selectedDisposer.empty()) {
+                return;
+            }
+
+            localState->dest.add([=](){
+                localState->worker.schedule(selectedDisposer.get());
+            });
+            localState->cs.add([=](){
+                localState->worker.schedule(selectedDisposer.get());
+            });
+
+            //
+            // The scheduler is FIFO for any time T. Since the observer is scheduling
+            // on_next/on_error/oncompleted the timed schedule calls must be resheduled
+            // when they occur to ensure that production happens after on_next/on_error/oncompleted
+            //
+
+            localState->worker.schedule(produce_time, [new_id, produce_time, localState](const rxsc::schedulable&){
+                localState->worker.schedule(release_window(new_id, produce_time, localState));
             });
         }
 
-        static void release_window(int id, rxsc::scheduler::clock_type::time_point expected, state_type state) {
-            if (id != state->subj_id)
-                return;
+        static std::function<void(const rxsc::schedulable&)> release_window(int id, rxsc::scheduler::clock_type::time_point expected, state_type state) {
+            auto release = [id, expected, state](const rxsc::schedulable&) {
+                if (id != state->subj_id)
+                    return;
 
-            state->subj.get_subscriber().on_completed();
-            state->subj = rxcpp::subjects::subject<T>();
-            state->dest.on_next(state->subj.get_observable().as_dynamic());
-            state->cursor = 0;
-            auto new_id = ++state->subj_id;
-            auto produce_time = expected + state->period;
-            auto localState = state;
-            state->worker.schedule(produce_time, [new_id, produce_time, localState](const rxsc::schedulable&){
-                release_window(new_id, produce_time, localState);
-            });
+                state->subj.get_subscriber().on_completed();
+                state->subj = rxcpp::subjects::subject<T>();
+                state->dest.on_next(state->subj.get_observable().as_dynamic());
+                state->cursor = 0;
+                auto new_id = ++state->subj_id;
+                auto produce_time = expected + state->period;
+                state->worker.schedule(produce_time, [new_id, produce_time, state](const rxsc::schedulable&){
+                    state->worker.schedule(release_window(new_id, produce_time, state));
+                });
+            };
+            auto selectedRelease = on_exception(
+                [&](){return state->coordinator.act(release);},
+                state->dest);
+            if (selectedRelease.empty()) {
+                return std::function<void(const rxsc::schedulable&)>();
+            }
+
+            return std::function<void(const rxsc::schedulable&)>(selectedRelease.get());
         }
 
         void on_next(T v) const {
-            state->subj.get_subscriber().on_next(v);
-            if (++state->cursor == state->count) {
-                release_window(state->subj_id, state->worker.now(), state);
+            auto localState = state;
+            auto work = [v, localState](const rxsc::schedulable&){
+                localState->subj.get_subscriber().on_next(v);
+                if (++localState->cursor == localState->count) {
+                    release_window(localState->subj_id, localState->worker.now(), localState);
+                }
+            };
+            auto selectedWork = on_exception(
+                [&](){return localState->coordinator.act(work);},
+                localState->dest);
+            if (selectedWork.empty()) {
+                return;
             }
+            localState->worker.schedule(selectedWork.get());
         }
 
         void on_error(std::exception_ptr e) const {
-            state->subj.get_subscriber().on_error(e);
-            state->dest.on_error(e);
+            auto localState = state;
+            auto work = [e, localState](const rxsc::schedulable&){
+                localState->subj.get_subscriber().on_error(e);
+                localState->dest.on_error(e);
+            };
+            auto selectedWork = on_exception(
+                [&](){return localState->coordinator.act(work);},
+                localState->dest);
+            if (selectedWork.empty()) {
+                return;
+            }
+            localState->worker.schedule(selectedWork.get());
         }
 
         void on_completed() const {
-            state->subj.get_subscriber().on_completed();
-            state->dest.on_completed();
+            auto localState = state;
+            auto work = [localState](const rxsc::schedulable&){
+                localState->subj.get_subscriber().on_completed();
+                localState->dest.on_completed();
+            };
+            auto selectedWork = on_exception(
+                [&](){return localState->coordinator.act(work);},
+                localState->dest);
+            if (selectedWork.empty()) {
+                return;
+            }
+            localState->worker.schedule(selectedWork.get());
         }
 
         static subscriber<T, observer_type> make(dest_type d, window_with_time_or_count_values v) {
-            auto cs = d.get_subscription();
-            auto coordinator = v.coordination.create_coordinator(cs);
+            auto cs = composite_subscription();
+            auto coordinator = v.coordination.create_coordinator();
 
-            return make_subscriber<T>(std::move(cs), observer_type(this_type(std::move(d), std::move(v), std::move(coordinator))));
+            return make_subscriber<T>(cs, observer_type(this_type(cs, std::move(d), std::move(v), std::move(coordinator))));
         }
     };
 

--- a/Rx/v2/test/operators/buffer.cpp
+++ b/Rx/v2/test/operators/buffer.cpp
@@ -712,13 +712,13 @@ SCENARIO("buffer with time, overlapping intervals", "[buffer_with_time][operator
 
             THEN("the output contains groups of ints"){
                 auto required = rxu::to_vector({
-                    v_on.next(300, rxu::to_vector({ 2, 3, 4 })),
-                    v_on.next(370, rxu::to_vector({ 4, 5, 6 })),
-                    v_on.next(440, rxu::to_vector({ 6, 7, 8 })),
-                    v_on.next(510, rxu::to_vector({ 8, 9 })),
-                    v_on.next(580, std::vector<int>()),
-                    v_on.next(600, std::vector<int>()),
-                    v_on.completed(600)
+                    v_on.next(301, rxu::to_vector({ 2, 3, 4 })),
+                    v_on.next(371, rxu::to_vector({ 4, 5, 6 })),
+                    v_on.next(441, rxu::to_vector({ 6, 7, 8 })),
+                    v_on.next(511, rxu::to_vector({ 8, 9 })),
+                    v_on.next(581, std::vector<int>()),
+                    v_on.next(601, std::vector<int>()),
+                    v_on.completed(601)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -769,11 +769,11 @@ SCENARIO("buffer with time, intervals with skips", "[buffer_with_time][operators
 
             THEN("the output contains groups of ints"){
                 auto required = rxu::to_vector({
-                    v_on.next(270, rxu::to_vector({ 2, 3 })),
-                    v_on.next(370, rxu::to_vector({ 5, 6 })),
-                    v_on.next(470, rxu::to_vector({ 8, 9 })),
-                    v_on.next(570, std::vector<int>()),
-                    v_on.completed(600)
+                    v_on.next(271, rxu::to_vector({ 2, 3 })),
+                    v_on.next(371, rxu::to_vector({ 5, 6 })),
+                    v_on.next(471, rxu::to_vector({ 8, 9 })),
+                    v_on.next(571, std::vector<int>()),
+                    v_on.completed(601)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -826,12 +826,12 @@ SCENARIO("buffer with time, error", "[buffer_with_time][operators]"){
 
             THEN("the output contains groups of ints"){
                 auto required = rxu::to_vector({
-                    v_on.next(300, rxu::to_vector({ 2, 3, 4 })),
-                    v_on.next(370, rxu::to_vector({ 4, 5, 6 })),
-                    v_on.next(440, rxu::to_vector({ 6, 7, 8 })),
-                    v_on.next(510, rxu::to_vector({ 8, 9 })),
-                    v_on.next(580, std::vector<int>()),
-                    v_on.error(600, ex)
+                    v_on.next(301, rxu::to_vector({ 2, 3, 4 })),
+                    v_on.next(371, rxu::to_vector({ 4, 5, 6 })),
+                    v_on.next(441, rxu::to_vector({ 6, 7, 8 })),
+                    v_on.next(511, rxu::to_vector({ 8, 9 })),
+                    v_on.next(581, std::vector<int>()),
+                    v_on.error(601, ex)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -883,7 +883,7 @@ SCENARIO("buffer with time, disposed", "[buffer_with_time][operators]"){
 
             THEN("the output contains groups of ints"){
                 auto required = rxu::to_vector({
-                    v_on.next(300, rxu::to_vector({ 2, 3, 4 })),
+                    v_on.next(301, rxu::to_vector({ 2, 3, 4 })),
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -891,7 +891,7 @@ SCENARIO("buffer with time, disposed", "[buffer_with_time][operators]"){
 
             THEN("there was one subscription and one unsubscription to the xs"){
                 auto required = rxu::to_vector({
-                    on.subscribe(200, 370)
+                    on.subscribe(200, 371)
                 });
                 auto actual = xs.subscriptions();
                 REQUIRE(required == actual);
@@ -934,11 +934,11 @@ SCENARIO("buffer with time, same", "[buffer_with_time][operators]"){
 
             THEN("the output contains groups of ints"){
                 auto required = rxu::to_vector({
-                    v_on.next(300, rxu::to_vector({ 2, 3, 4 })),
-                    v_on.next(400, rxu::to_vector({ 5, 6, 7 })),
-                    v_on.next(500, rxu::to_vector({ 8, 9 })),
-                    v_on.next(600, std::vector<int>()),
-                    v_on.completed(600)
+                    v_on.next(301, rxu::to_vector({ 2, 3, 4 })),
+                    v_on.next(401, rxu::to_vector({ 5, 6, 7 })),
+                    v_on.next(501, rxu::to_vector({ 8, 9 })),
+                    v_on.next(601, std::vector<int>()),
+                    v_on.completed(601)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -989,14 +989,14 @@ SCENARIO("buffer with time or count, basic", "[buffer_with_time_or_count][operat
 
             THEN("the output contains groups of ints"){
                 auto required = rxu::to_vector({
-                    v_on.next(240, rxu::to_vector({ 1, 2, 3 })),
-                    v_on.next(310, rxu::to_vector({ 4 })),
-                    v_on.next(370, rxu::to_vector({ 5, 6, 7 })),
-                    v_on.next(440, rxu::to_vector({ 8 })),
-                    v_on.next(510, rxu::to_vector({ 9 })),
-                    v_on.next(580, std::vector<int>()),
-                    v_on.next(600, std::vector<int>()),
-                    v_on.completed(600)
+                    v_on.next(241, rxu::to_vector({ 1, 2, 3 })),
+                    v_on.next(312, rxu::to_vector({ 4 })),
+                    v_on.next(371, rxu::to_vector({ 5, 6, 7 })),
+                    v_on.next(442, rxu::to_vector({ 8 })),
+                    v_on.next(512, rxu::to_vector({ 9 })),
+                    v_on.next(582, std::vector<int>()),
+                    v_on.next(601, std::vector<int>()),
+                    v_on.completed(601)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -1049,13 +1049,13 @@ SCENARIO("buffer with time or count, error", "[buffer_with_time_or_count][operat
 
             THEN("the output contains groups of ints"){
                 auto required = rxu::to_vector({
-                    v_on.next(240, rxu::to_vector({ 1, 2, 3 })),
-                    v_on.next(310, rxu::to_vector({ 4 })),
-                    v_on.next(370, rxu::to_vector({ 5, 6, 7 })),
-                    v_on.next(440, rxu::to_vector({ 8 })),
-                    v_on.next(510, rxu::to_vector({ 9 })),
-                    v_on.next(580, std::vector<int>()),
-                    v_on.error(600, ex)
+                    v_on.next(241, rxu::to_vector({ 1, 2, 3 })),
+                    v_on.next(312, rxu::to_vector({ 4 })),
+                    v_on.next(371, rxu::to_vector({ 5, 6, 7 })),
+                    v_on.next(442, rxu::to_vector({ 8 })),
+                    v_on.next(512, rxu::to_vector({ 9 })),
+                    v_on.next(582, std::vector<int>()),
+                    v_on.error(601, ex)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -1102,14 +1102,14 @@ SCENARIO("buffer with time or count, dispose", "[buffer_with_time_or_count][oper
                         // forget type to workaround lambda deduction bug on msvc 2013
                         .as_dynamic();
                 },
-                370
+                372
             );
 
             THEN("the output contains groups of ints"){
                 auto required = rxu::to_vector({
-                    v_on.next(240, rxu::to_vector({ 1, 2, 3 })),
-                    v_on.next(310, rxu::to_vector({ 4 })),
-                    v_on.next(370, rxu::to_vector({ 5, 6, 7 })),
+                    v_on.next(241, rxu::to_vector({ 1, 2, 3 })),
+                    v_on.next(312, rxu::to_vector({ 4 })),
+                    v_on.next(371, rxu::to_vector({ 5, 6, 7 })),
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -1117,7 +1117,7 @@ SCENARIO("buffer with time or count, dispose", "[buffer_with_time_or_count][oper
 
             THEN("there was one subscription and one unsubscription to the xs"){
                 auto required = rxu::to_vector({
-                    on.subscribe(200, 370)
+                    on.subscribe(200, 373)
                 });
                 auto actual = xs.subscriptions();
                 REQUIRE(required == actual);
@@ -1156,14 +1156,14 @@ SCENARIO("buffer with time or count, only time triggered", "[buffer_with_time_or
 
             THEN("the output contains groups of ints"){
                 auto required = rxu::to_vector({
-                    v_on.next(300, rxu::to_vector({ 1 })),
-                    v_on.next(400, rxu::to_vector({ 2 })),
-                    v_on.next(500, std::vector<int>()),
-                    v_on.next(600, rxu::to_vector({ 3 })),
-                    v_on.next(700, rxu::to_vector({ 4, 5 })),
-                    v_on.next(800, std::vector<int>()),
-                    v_on.next(850, std::vector<int>()),
-                    v_on.completed(850)
+                    v_on.next(301, rxu::to_vector({ 1 })),
+                    v_on.next(401, rxu::to_vector({ 2 })),
+                    v_on.next(501, std::vector<int>()),
+                    v_on.next(601, rxu::to_vector({ 3 })),
+                    v_on.next(701, rxu::to_vector({ 4, 5 })),
+                    v_on.next(801, std::vector<int>()),
+                    v_on.next(851, std::vector<int>()),
+                    v_on.completed(851)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);

--- a/Rx/v2/test/operators/window.cpp
+++ b/Rx/v2/test/operators/window.cpp
@@ -343,23 +343,23 @@ SCENARIO("window with time, basic", "[window_with_time][operators]"){
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(210, 2),
-                    on.next(240, 3),
-                    on.next(270, 4),
-                    on.next(270, 4),
-                    on.next(320, 5),
-                    on.next(320, 5),
-                    on.next(360, 6),
-                    on.next(360, 6),
-                    on.next(390, 7),
-                    on.next(390, 7),
-                    on.next(410, 8),
-                    on.next(410, 8),
-                    on.next(460, 9),
-                    on.next(460, 9),
-                    on.next(470, 10),
-                    on.next(470, 10),
-                    on.completed(490)
+                    on.next(211, 2),
+                    on.next(241, 3),
+                    on.next(271, 4),
+                    on.next(271, 4),
+                    on.next(321, 5),
+                    on.next(321, 5),
+                    on.next(361, 6),
+                    on.next(361, 6),
+                    on.next(391, 7),
+                    on.next(391, 7),
+                    on.next(411, 8),
+                    on.next(411, 8),
+                    on.next(461, 9),
+                    on.next(461, 9),
+                    on.next(471, 10),
+                    on.next(471, 10),
+                    on.completed(491)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -413,16 +413,16 @@ SCENARIO("window with time, basic same", "[window_with_time][operators]"){
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(210, 2),
-                    on.next(240, 3),
-                    on.next(270, 4),
-                    on.next(320, 5),
-                    on.next(360, 6),
-                    on.next(390, 7),
-                    on.next(410, 8),
-                    on.next(460, 9),
-                    on.next(470, 10),
-                    on.completed(490)
+                    on.next(211, 2),
+                    on.next(241, 3),
+                    on.next(271, 4),
+                    on.next(321, 5),
+                    on.next(361, 6),
+                    on.next(391, 7),
+                    on.next(411, 8),
+                    on.next(461, 9),
+                    on.next(471, 10),
+                    on.completed(491)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -475,18 +475,18 @@ SCENARIO("window with time, basic 1", "[window_with_time][operators]"){
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(210, 2),
-                    on.next(240, 3),
-                    on.next(280, 4),
-                    on.next(280, 4),
-                    on.next(320, 5),
-                    on.next(350, 6),
-                    on.next(350, 6),
-                    on.next(380, 7),
-                    on.next(420, 8),
-                    on.next(420, 8),
-                    on.next(470, 9),
-                    on.completed(600)
+                    on.next(211, 2),
+                    on.next(241, 3),
+                    on.next(281, 4),
+                    on.next(281, 4),
+                    on.next(321, 5),
+                    on.next(351, 6),
+                    on.next(351, 6),
+                    on.next(381, 7),
+                    on.next(421, 8),
+                    on.next(421, 8),
+                    on.next(471, 9),
+                    on.completed(601)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -539,13 +539,13 @@ SCENARIO("window with time, basic 2", "[window_with_time][operators]"){
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(210, 2),
-                    on.next(240, 3),
-                    on.next(320, 5),
-                    on.next(350, 6),
-                    on.next(420, 8),
-                    on.next(470, 9),
-                    on.completed(600)
+                    on.next(211, 2),
+                    on.next(241, 3),
+                    on.next(321, 5),
+                    on.next(351, 6),
+                    on.next(421, 8),
+                    on.next(471, 9),
+                    on.completed(601)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -600,18 +600,18 @@ SCENARIO("window with time, error", "[window_with_time][operators]"){
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(210, 2),
-                    on.next(240, 3),
-                    on.next(280, 4),
-                    on.next(280, 4),
-                    on.next(320, 5),
-                    on.next(350, 6),
-                    on.next(350, 6),
-                    on.next(380, 7),
-                    on.next(420, 8),
-                    on.next(420, 8),
-                    on.next(470, 9),
-                    on.error(600, ex)
+                    on.next(211, 2),
+                    on.next(241, 3),
+                    on.next(281, 4),
+                    on.next(281, 4),
+                    on.next(321, 5),
+                    on.next(351, 6),
+                    on.next(351, 6),
+                    on.next(381, 7),
+                    on.next(421, 8),
+                    on.next(421, 8),
+                    on.next(471, 9),
+                    on.error(601, ex)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -665,13 +665,13 @@ SCENARIO("window with time, disposed", "[window_with_time][operators]"){
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(210, 2),
-                    on.next(240, 3),
-                    on.next(280, 4),
-                    on.next(280, 4),
-                    on.next(320, 5),
-                    on.next(350, 6),
-                    on.next(350, 6),
+                    on.next(211, 2),
+                    on.next(241, 3),
+                    on.next(281, 4),
+                    on.next(281, 4),
+                    on.next(321, 5),
+                    on.next(351, 6),
+                    on.next(351, 6),
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -679,7 +679,7 @@ SCENARIO("window with time, disposed", "[window_with_time][operators]"){
 
             THEN("there was one subscription and one unsubscription to the observable"){
                 auto required = rxu::to_vector({
-                    o_on.subscribe(200, 370)
+                    o_on.subscribe(200, 371)
                 });
                 auto actual = xs.subscriptions();
                 REQUIRE(required == actual);
@@ -724,15 +724,15 @@ SCENARIO("window with time, basic same 1", "[window_with_time][operators]"){
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(210, 2),
-                    on.next(240, 3),
-                    on.next(280, 4),
-                    on.next(320, 5),
-                    on.next(350, 6),
-                    on.next(380, 7),
-                    on.next(420, 8),
-                    on.next(470, 9),
-                    on.completed(600)
+                    on.next(211, 2),
+                    on.next(241, 3),
+                    on.next(281, 4),
+                    on.next(321, 5),
+                    on.next(351, 6),
+                    on.next(381, 7),
+                    on.next(421, 8),
+                    on.next(471, 9),
+                    on.completed(601)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -785,16 +785,16 @@ SCENARIO("window with time or count, basic", "[window_with_time_or_count][operat
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(205, 1),
-                    on.next(210, 2),
-                    on.next(240, 3),
-                    on.next(280, 4),
-                    on.next(320, 5),
-                    on.next(350, 6),
-                    on.next(370, 7),
-                    on.next(420, 8),
-                    on.next(470, 9),
-                    on.completed(600)
+                    on.next(206, 1),
+                    on.next(211, 2),
+                    on.next(241, 3),
+                    on.next(281, 4),
+                    on.next(321, 5),
+                    on.next(351, 6),
+                    on.next(371, 7),
+                    on.next(421, 8),
+                    on.next(471, 9),
+                    on.completed(601)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -849,16 +849,16 @@ SCENARIO("window with time or count, error", "[window_with_time_or_count][operat
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(205, 1),
-                    on.next(210, 2),
-                    on.next(240, 3),
-                    on.next(280, 4),
-                    on.next(320, 5),
-                    on.next(350, 6),
-                    on.next(370, 7),
-                    on.next(420, 8),
-                    on.next(470, 9),
-                    on.error(600, ex)
+                    on.next(206, 1),
+                    on.next(211, 2),
+                    on.next(241, 3),
+                    on.next(281, 4),
+                    on.next(321, 5),
+                    on.next(351, 6),
+                    on.next(371, 7),
+                    on.next(421, 8),
+                    on.next(471, 9),
+                    on.error(601, ex)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -907,18 +907,18 @@ SCENARIO("window with time or count, disposed", "[window_with_time_or_count][ope
                         // forget type to workaround lambda deduction bug on msvc 2013
                         .as_dynamic();
                 },
-                370
+                372
             );
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(205, 1),
-                    on.next(210, 2),
-                    on.next(240, 3),
-                    on.next(280, 4),
-                    on.next(320, 5),
-                    on.next(350, 6),
-                    on.next(370, 7)
+                    on.next(206, 1),
+                    on.next(211, 2),
+                    on.next(241, 3),
+                    on.next(281, 4),
+                    on.next(321, 5),
+                    on.next(351, 6),
+                    on.next(371, 7)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
@@ -926,7 +926,7 @@ SCENARIO("window with time or count, disposed", "[window_with_time_or_count][ope
 
             THEN("there was one subscription and one unsubscription to the observable"){
                 auto required = rxu::to_vector({
-                    o_on.subscribe(200, 370)
+                    o_on.subscribe(200, 373)
                 });
                 auto actual = xs.subscriptions();
                 REQUIRE(required == actual);
@@ -967,12 +967,12 @@ SCENARIO("window with time or count, only time triggered", "[window_with_time_or
 
             THEN("the output contains merged groups of ints"){
                 auto required = rxu::to_vector({
-                    on.next(205, 1),
-                    on.next(305, 2),
-                    on.next(505, 3),
-                    on.next(605, 4),
-                    on.next(610, 5),
-                    on.completed(850)
+                    on.next(206, 1),
+                    on.next(306, 2),
+                    on.next(506, 3),
+                    on.next(606, 4),
+                    on.next(611, 5),
+                    on.completed(851)
                 });
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);


### PR DESCRIPTION
The time operators use a scheduler and an input stream, these must be coordinated. 
scheduling all the signals using the same worker guarantees that they will not overlap. when using an immediate scheduler no serialization primitives are used.

NOTE: I want to revamp the scheduler to make virtual methods opt-in and remove all the action/subscribeable/recursion/coordination constructs.
