### PR TITLE
Reduce

### DIFF
--- a/Rx/v2/examples/doxygen/blocking_observable.cpp
+++ b/Rx/v2/examples/doxygen/blocking_observable.cpp
@@ -1,0 +1,92 @@
+#include "rxcpp/rx.hpp"
+
+#include "rxcpp/rx-test.hpp"
+#include "catch.hpp"
+
+SCENARIO("blocking first sample"){
+    printf("//! [blocking first sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto first = values.first();
+    printf("first = %d\n", first);
+    printf("//! [blocking first sample]\n");
+}
+
+SCENARIO("blocking first empty sample"){
+    printf("//! [blocking first empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().as_blocking();
+    try {
+        auto first = values.first();
+        printf("first = %d\n", first);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
+    printf("//! [blocking first empty sample]\n");
+}
+
+SCENARIO("blocking last sample"){
+    printf("//! [blocking last sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto last = values.last();
+    printf("last = %d\n", last);
+    printf("//! [blocking last sample]\n");
+}
+
+SCENARIO("blocking last empty sample"){
+    printf("//! [blocking last empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().as_blocking();
+    try {
+        auto last = values.last();
+        printf("last = %d\n", last);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
+    printf("//! [blocking last empty sample]\n");
+}
+
+SCENARIO("blocking count sample"){
+    printf("//! [blocking count sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto count = values.count();
+    printf("count = %d\n", count);
+    printf("//! [blocking count sample]\n");
+}
+
+SCENARIO("blocking sum sample"){
+    printf("//! [blocking sum sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto sum = values.sum();
+    printf("sum = %d\n", sum);
+    printf("//! [blocking sum sample]\n");
+}
+
+SCENARIO("blocking sum empty sample"){
+    printf("//! [blocking sum empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().as_blocking();
+    try {
+        auto sum = values.sum();
+        printf("sum = %d\n", sum);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
+    printf("//! [blocking sum empty sample]\n");
+}
+
+SCENARIO("blocking average sample"){
+    printf("//! [blocking average sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto average = values.average();
+    printf("average = %d\n", average);
+    printf("//! [blocking average sample]\n");
+}
+
+SCENARIO("blocking average empty sample"){
+    printf("//! [blocking average empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().as_blocking();
+    try {
+        auto average = values.average();
+        printf("average = %d\n", average);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
+    printf("//! [blocking average empty sample]\n");
+}

--- a/Rx/v2/examples/doxygen/math.cpp
+++ b/Rx/v2/examples/doxygen/math.cpp
@@ -13,24 +13,21 @@ SCENARIO("first sample"){
     printf("//! [first sample]\n");
 }
 
-//SCENARIO("first empty sample"){
-//    printf("//! [first empty sample]\n");
-//    auto values = rxcpp::observable<>::empty<int>().first();
-//    values.
-//        subscribe(
-//            [](int v){printf("OnNext: %d\n", v);},
-//            [](std::exception_ptr ep){
-//                try {std::rethrow_exception(ep);}
-//                catch (const std::exception& ex) {
-//                    printf("OnError: %s\n", ex.what());
-//                }
-//                catch (...) {
-//                    printf("OnError:\n");
-//                }
-//            },
-//            [](){printf("OnCompleted\n");});
-//    printf("//! [first empty sample]\n");
-//}
+SCENARIO("first empty sample"){
+    printf("//! [first empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().first();
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [first empty sample]\n");
+}
 
 SCENARIO("last sample"){
     printf("//! [last sample]\n");
@@ -42,21 +39,21 @@ SCENARIO("last sample"){
     printf("//! [last sample]\n");
 }
 
-//SCENARIO("last empty sample"){
-//    printf("//! [last empty sample]\n");
-//    auto values = rxcpp::observable<>::empty<int>().last();
-//    values.
-//        subscribe(
-//            [](int v){printf("OnNext: %d\n", v);},
-//            [](std::exception_ptr ep){
-//                try {std::rethrow_exception(ep);}
-//                catch (const std::exception& ex) {
-//                    printf("OnError: %s\n", ex.what());
-//                }
-//            },
-//            [](){printf("OnCompleted\n");});
-//    printf("//! [last empty sample]\n");
-//}
+SCENARIO("last empty sample"){
+    printf("//! [last empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().last();
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [last empty sample]\n");
+}
 
 SCENARIO("count sample"){
     printf("//! [count sample]\n");
@@ -78,6 +75,22 @@ SCENARIO("sum sample"){
     printf("//! [sum sample]\n");
 }
 
+SCENARIO("sum empty sample"){
+    printf("//! [sum empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().sum();
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [sum empty sample]\n");
+}
+
 SCENARIO("average sample"){
     printf("//! [average sample]\n");
     auto values = rxcpp::observable<>::range(1, 4).average();
@@ -86,4 +99,20 @@ SCENARIO("average sample"){
             [](double v){printf("OnNext: %lf\n", v);},
             [](){printf("OnCompleted\n");});
     printf("//! [average sample]\n");
+}
+
+SCENARIO("average empty sample"){
+    printf("//! [average empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().average();
+    values.
+        subscribe(
+            [](double v){printf("OnNext: %lf\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [average empty sample]\n");
 }

--- a/Rx/v2/examples/doxygen/reduce.cpp
+++ b/Rx/v2/examples/doxygen/reduce.cpp
@@ -22,3 +22,23 @@ SCENARIO("reduce sample"){
             [](){printf("OnCompleted\n");});
     printf("//! [reduce sample]\n");
 }
+
+SCENARIO("reduce empty sample"){
+    printf("//! [reduce empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().
+        reduce(
+            1,
+            [](int seed, int){return seed;},
+            [](int res){return res;});
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [reduce empty sample]\n");
+}

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -1918,6 +1918,10 @@ public:
         Geometric mean of source values:
         \snippet reduce.cpp reduce sample
         \snippet output.txt reduce sample
+
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        \snippet reduce.cpp reduce empty sample
+        \snippet output.txt reduce empty sample
     */
     template<class Seed, class Accumulator, class ResultSelector>
     auto reduce(Seed seed, Accumulator&& a, ResultSelector&& rs) const
@@ -1948,6 +1952,10 @@ public:
         \sample
         \snippet math.cpp first sample
         \snippet output.txt first sample
+
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        \snippet math.cpp first empty sample
+        \snippet output.txt first empty sample
     */
     auto first() const
         -> observable<T>;
@@ -1959,6 +1967,10 @@ public:
         \sample
         \snippet math.cpp last sample
         \snippet output.txt last sample
+
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        \snippet math.cpp last empty sample
+        \snippet output.txt last empty sample
     */
     auto last() const
         -> observable<T>;
@@ -1981,6 +1993,10 @@ public:
         \sample
         \snippet math.cpp sum sample
         \snippet output.txt sum sample
+
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        \snippet math.cpp sum empty sample
+        \snippet output.txt sum empty sample
     */
     auto sum() const
         /// \cond SHOW_SERVICE_MEMBERS
@@ -1997,6 +2013,10 @@ public:
         \sample
         \snippet math.cpp average sample
         \snippet output.txt average sample
+
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        \snippet math.cpp average empty sample
+        \snippet output.txt average empty sample
     */
     auto average() const
         /// \cond SHOW_SERVICE_MEMBERS

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -264,11 +264,7 @@ public:
     }
 
     T first() {
-        rxu::maybe<T> result;
-        composite_subscription cs;
-        subscribe(cs, [&](T v){result.reset(v); cs.unsubscribe();});
-        if (result.empty()) throw std::runtime_error("No elements");
-        return result.get();
+        return source.first().as_blocking().last();
     }
 
     T last() const {

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -263,27 +263,108 @@ public:
         return blocking_subscribe(source, std::forward<ArgN>(an)...);
     }
 
+    /*! Return the first item emitted by this blocking_observable, or throw an std::runtime_error exception if it emits no items.
+
+        \return  The first item emitted by this blocking_observable.
+
+        \note  If the source observable calls on_error, the raised exception is rethrown by this method.
+
+        \sample
+        When the source observable emits at least one item:
+        \snippet blocking_observable.cpp blocking first sample
+        \snippet output.txt blocking first sample
+
+        When the source observable is empty:
+        \snippet blocking_observable.cpp blocking first empty sample
+        \snippet output.txt blocking first empty sample
+    */
     T first() {
         return source.first().as_blocking().last();
     }
 
+    /*! Return the last item emitted by this blocking_observable, or throw an std::runtime_error exception if it emits no items.
+
+        \return  The last item emitted by this blocking_observable.
+
+        \note  If the source observable calls on_error, the raised exception is rethrown by this method.
+
+        \sample
+        When the source observable emits at least one item:
+        \snippet blocking_observable.cpp blocking last sample
+        \snippet output.txt blocking last sample
+
+        When the source observable is empty:
+        \snippet blocking_observable.cpp blocking last empty sample
+        \snippet output.txt blocking last empty sample
+    */
     T last() const {
         rxu::maybe<T> result;
-        subscribe([&](T v){result.reset(v);});
-        if (result.empty()) throw std::runtime_error("No elements");
+        rxu::maybe<std::exception_ptr> error;
+        subscribe(
+            [&](T v){result.reset(v);},
+            [&](std::exception_ptr ep){error.reset(ep);});
+        if (!error.empty())
+            std::rethrow_exception(error.get());
+        if (result.empty())
+            throw std::runtime_error("No elements");
         return result.get();
     }
 
+    /*! Return the total number of items emitted by this blocking_observable.
+
+        \return  The total number of items emitted by this blocking_observable.
+
+        \note  If the source observable calls on_error, the raised exception is rethrown by this method.
+
+        \sample
+        \snippet blocking_observable.cpp blocking count sample
+        \snippet output.txt blocking count sample
+    */
     int count() const {
         rxu::maybe<T> result;
+        rxu::maybe<std::exception_ptr> error;
         source.count().as_blocking().subscribe(
             [&](T v){result.reset(v);},
-            [](std::exception_ptr){result.reset(0);});
+            [&](std::exception_ptr ep){error.reset(ep);});
+        if (!error.empty())
+            std::rethrow_exception(error.get());
         return result.get();
     }
+
+    /*! Return the sum of all items emitted by this blocking_observable, or throw an std::runtime_error exception if it emits no items.
+
+        \return  The sum of all items emitted by this blocking_observable.
+
+        \note  If the source observable calls on_error, the raised exception is rethrown by this method.
+
+        \sample
+        When the source observable emits at least one item:
+        \snippet blocking_observable.cpp blocking sum sample
+        \snippet output.txt blocking sum sample
+
+        When the source observable is empty:
+        \snippet blocking_observable.cpp blocking sum empty sample
+        \snippet output.txt blocking sum empty sample
+    */
     T sum() const {
         return source.sum().as_blocking().last();
     }
+
+    /*! Return the average value of all items emitted by this blocking_observable, or throw an std::runtime_error exception if it emits no items.
+
+        \return  The average value of all items emitted by this blocking_observable.
+
+        \note  If the source observable calls on_error, the raised exception is rethrown by this method.
+
+        \sample
+        When the source observable emits at least one item:
+        \snippet blocking_observable.cpp blocking average sample
+        \snippet output.txt blocking average sample
+
+        When the source observable is empty:
+        \snippet blocking_observable.cpp blocking average empty sample
+        \snippet output.txt blocking average empty sample
+    */
     double average() const {
         return source.average().as_blocking().last();
     }

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -158,6 +158,7 @@ if(DOXYGEN_FOUND)
         ${DOXY_EXAMPLES_SRC_DIR}/main.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/amb.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/as_dynamic.cpp
+        ${DOXY_EXAMPLES_SRC_DIR}/blocking_observable.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/buffer.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/combine_latest.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/concat.cpp


### PR DESCRIPTION
1. Implement on_error behavior for observable<T>::reduce and operators using it.
2. Throw an exception on aggregating methods of blocking_observable when the source is empty. Old behavior: abort() or return 0.
2. Throw an exception ```EX``` on aggregating methods of blocking_observable when the source calls ```on_error(EX)```. Old behavior: abort().