### PR TITLE
Reduce

### DIFF
--- a/Rx/v2/examples/doxygen/blocking_observable.cpp
+++ b/Rx/v2/examples/doxygen/blocking_observable.cpp
@@ -17,7 +17,7 @@ SCENARIO("blocking first empty sample"){
     try {
         auto first = values.first();
         printf("first = %d\n", first);
-    } catch (const std::exception& ex) {
+    } catch (const rxcpp::empty_error& ex) {
         printf("Exception: %s\n", ex.what());
     }
     printf("//! [blocking first empty sample]\n");
@@ -37,7 +37,7 @@ SCENARIO("blocking last empty sample"){
     try {
         auto last = values.last();
         printf("last = %d\n", last);
-    } catch (const std::exception& ex) {
+    } catch (const rxcpp::empty_error& ex) {
         printf("Exception: %s\n", ex.what());
     }
     printf("//! [blocking last empty sample]\n");
@@ -49,6 +49,16 @@ SCENARIO("blocking count sample"){
     auto count = values.count();
     printf("count = %d\n", count);
     printf("//! [blocking count sample]\n");
+}
+
+SCENARIO("blocking count error sample"){
+    printf("//! [blocking count error sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).
+        concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
+        as_blocking();
+    auto count = values.count();
+    printf("count = %d\n", count);
+    printf("//! [blocking count error sample]\n");
 }
 
 SCENARIO("blocking sum sample"){
@@ -65,17 +75,27 @@ SCENARIO("blocking sum empty sample"){
     try {
         auto sum = values.sum();
         printf("sum = %d\n", sum);
-    } catch (const std::exception& ex) {
+    } catch (const rxcpp::empty_error& ex) {
         printf("Exception: %s\n", ex.what());
     }
     printf("//! [blocking sum empty sample]\n");
 }
 
+SCENARIO("blocking sum error sample"){
+    printf("//! [blocking sum error sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).
+        concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
+        as_blocking();
+    auto sum = values.sum();
+    printf("sum = %d\n", sum);
+    printf("//! [blocking sum error sample]\n");
+}
+
 SCENARIO("blocking average sample"){
     printf("//! [blocking average sample]\n");
-    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto values = rxcpp::observable<>::range(1, 4).as_blocking();
     auto average = values.average();
-    printf("average = %d\n", average);
+    printf("average = %lf\n", average);
     printf("//! [blocking average sample]\n");
 }
 
@@ -84,9 +104,19 @@ SCENARIO("blocking average empty sample"){
     auto values = rxcpp::observable<>::empty<int>().as_blocking();
     try {
         auto average = values.average();
-        printf("average = %d\n", average);
-    } catch (const std::exception& ex) {
+        printf("average = %lf\n", average);
+    } catch (const rxcpp::empty_error& ex) {
         printf("Exception: %s\n", ex.what());
     }
     printf("//! [blocking average empty sample]\n");
+}
+
+SCENARIO("blocking average error sample"){
+    printf("//! [blocking average error sample]\n");
+    auto values = rxcpp::observable<>::range(1, 4).
+        concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
+        as_blocking();
+    auto average = values.average();
+    printf("average = %lf\n", average);
+    printf("//! [blocking average error sample]\n");
 }

--- a/Rx/v2/examples/doxygen/blocking_observable.cpp
+++ b/Rx/v2/examples/doxygen/blocking_observable.cpp
@@ -25,8 +25,7 @@ SCENARIO("blocking first empty sample"){
 
 SCENARIO("blocking first error sample"){
     printf("//! [blocking first error sample]\n");
-    auto values = rxcpp::observable<>::range(1, 3).
-        concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
+    auto values = rxcpp::observable<>::error<int>(std::runtime_error("Error from source")).
         as_blocking();
     try {
         auto first = values.first();

--- a/Rx/v2/examples/doxygen/blocking_observable.cpp
+++ b/Rx/v2/examples/doxygen/blocking_observable.cpp
@@ -23,6 +23,20 @@ SCENARIO("blocking first empty sample"){
     printf("//! [blocking first empty sample]\n");
 }
 
+SCENARIO("blocking first error sample"){
+    printf("//! [blocking first error sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).
+        concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
+        as_blocking();
+    try {
+        auto first = values.first();
+        printf("first = %d\n", first);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
+    printf("//! [blocking first error sample]\n");
+}
+
 SCENARIO("blocking last sample"){
     printf("//! [blocking last sample]\n");
     auto values = rxcpp::observable<>::range(1, 3).as_blocking();
@@ -43,6 +57,20 @@ SCENARIO("blocking last empty sample"){
     printf("//! [blocking last empty sample]\n");
 }
 
+SCENARIO("blocking last error sample"){
+    printf("//! [blocking last error sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).
+        concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
+        as_blocking();
+    try {
+        auto last = values.last();
+        printf("last = %d\n", last);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
+    printf("//! [blocking last error sample]\n");
+}
+
 SCENARIO("blocking count sample"){
     printf("//! [blocking count sample]\n");
     auto values = rxcpp::observable<>::range(1, 3).as_blocking();
@@ -56,8 +84,12 @@ SCENARIO("blocking count error sample"){
     auto values = rxcpp::observable<>::range(1, 3).
         concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
         as_blocking();
-    auto count = values.count();
-    printf("count = %d\n", count);
+    try {
+        auto count = values.count();
+        printf("count = %d\n", count);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
     printf("//! [blocking count error sample]\n");
 }
 
@@ -86,8 +118,12 @@ SCENARIO("blocking sum error sample"){
     auto values = rxcpp::observable<>::range(1, 3).
         concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
         as_blocking();
-    auto sum = values.sum();
-    printf("sum = %d\n", sum);
+    try {
+        auto sum = values.sum();
+        printf("sum = %d\n", sum);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
     printf("//! [blocking sum error sample]\n");
 }
 
@@ -116,7 +152,11 @@ SCENARIO("blocking average error sample"){
     auto values = rxcpp::observable<>::range(1, 4).
         concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
         as_blocking();
-    auto average = values.average();
-    printf("average = %lf\n", average);
+    try {
+        auto average = values.average();
+        printf("average = %lf\n", average);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
     printf("//! [blocking average error sample]\n");
 }

--- a/Rx/v2/examples/doxygen/blocking_observable.cpp
+++ b/Rx/v2/examples/doxygen/blocking_observable.cpp
@@ -1,0 +1,92 @@
+#include "rxcpp/rx.hpp"
+
+#include "rxcpp/rx-test.hpp"
+#include "catch.hpp"
+
+SCENARIO("blocking first sample"){
+    printf("//! [blocking first sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto first = values.first();
+    printf("first = %d\n", first);
+    printf("//! [blocking first sample]\n");
+}
+
+SCENARIO("blocking first empty sample"){
+    printf("//! [blocking first empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().as_blocking();
+    try {
+        auto first = values.first();
+        printf("first = %d\n", first);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
+    printf("//! [blocking first empty sample]\n");
+}
+
+SCENARIO("blocking last sample"){
+    printf("//! [blocking last sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto last = values.last();
+    printf("last = %d\n", last);
+    printf("//! [blocking last sample]\n");
+}
+
+SCENARIO("blocking last empty sample"){
+    printf("//! [blocking last empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().as_blocking();
+    try {
+        auto last = values.last();
+        printf("last = %d\n", last);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
+    printf("//! [blocking last empty sample]\n");
+}
+
+SCENARIO("blocking count sample"){
+    printf("//! [blocking count sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto count = values.count();
+    printf("count = %d\n", count);
+    printf("//! [blocking count sample]\n");
+}
+
+SCENARIO("blocking sum sample"){
+    printf("//! [blocking sum sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto sum = values.sum();
+    printf("sum = %d\n", sum);
+    printf("//! [blocking sum sample]\n");
+}
+
+SCENARIO("blocking sum empty sample"){
+    printf("//! [blocking sum empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().as_blocking();
+    try {
+        auto sum = values.sum();
+        printf("sum = %d\n", sum);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
+    printf("//! [blocking sum empty sample]\n");
+}
+
+SCENARIO("blocking average sample"){
+    printf("//! [blocking average sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).as_blocking();
+    auto average = values.average();
+    printf("average = %d\n", average);
+    printf("//! [blocking average sample]\n");
+}
+
+SCENARIO("blocking average empty sample"){
+    printf("//! [blocking average empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().as_blocking();
+    try {
+        auto average = values.average();
+        printf("average = %d\n", average);
+    } catch (const std::exception& ex) {
+        printf("Exception: %s\n", ex.what());
+    }
+    printf("//! [blocking average empty sample]\n");
+}

--- a/Rx/v2/examples/doxygen/math.cpp
+++ b/Rx/v2/examples/doxygen/math.cpp
@@ -73,6 +73,12 @@ SCENARIO("count error sample"){
     values.
         subscribe(
             [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::runtime_error& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
             [](){printf("OnCompleted\n");});
     printf("//! [count error sample]\n");
 }
@@ -111,6 +117,12 @@ SCENARIO("sum error sample"){
     values.
         subscribe(
             [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::runtime_error& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
             [](){printf("OnCompleted\n");});
     printf("//! [sum error sample]\n");
 }
@@ -149,6 +161,12 @@ SCENARIO("average error sample"){
     values.
         subscribe(
             [](double v){printf("OnNext: %lf\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::runtime_error& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
             [](){printf("OnCompleted\n");});
     printf("//! [average error sample]\n");
 }

--- a/Rx/v2/examples/doxygen/math.cpp
+++ b/Rx/v2/examples/doxygen/math.cpp
@@ -13,24 +13,21 @@ SCENARIO("first sample"){
     printf("//! [first sample]\n");
 }
 
-//SCENARIO("first empty sample"){
-//    printf("//! [first empty sample]\n");
-//    auto values = rxcpp::observable<>::empty<int>().first();
-//    values.
-//        subscribe(
-//            [](int v){printf("OnNext: %d\n", v);},
-//            [](std::exception_ptr ep){
-//                try {std::rethrow_exception(ep);}
-//                catch (const std::exception& ex) {
-//                    printf("OnError: %s\n", ex.what());
-//                }
-//                catch (...) {
-//                    printf("OnError:\n");
-//                }
-//            },
-//            [](){printf("OnCompleted\n");});
-//    printf("//! [first empty sample]\n");
-//}
+SCENARIO("first empty sample"){
+    printf("//! [first empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().first();
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [first empty sample]\n");
+}
 
 SCENARIO("last sample"){
     printf("//! [last sample]\n");
@@ -42,21 +39,21 @@ SCENARIO("last sample"){
     printf("//! [last sample]\n");
 }
 
-//SCENARIO("last empty sample"){
-//    printf("//! [last empty sample]\n");
-//    auto values = rxcpp::observable<>::empty<int>().last();
-//    values.
-//        subscribe(
-//            [](int v){printf("OnNext: %d\n", v);},
-//            [](std::exception_ptr ep){
-//                try {std::rethrow_exception(ep);}
-//                catch (const std::exception& ex) {
-//                    printf("OnError: %s\n", ex.what());
-//                }
-//            },
-//            [](){printf("OnCompleted\n");});
-//    printf("//! [last empty sample]\n");
-//}
+SCENARIO("last empty sample"){
+    printf("//! [last empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().last();
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [last empty sample]\n");
+}
 
 SCENARIO("count sample"){
     printf("//! [count sample]\n");
@@ -78,6 +75,22 @@ SCENARIO("sum sample"){
     printf("//! [sum sample]\n");
 }
 
+SCENARIO("sum empty sample"){
+    printf("//! [sum empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().sum();
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [sum empty sample]\n");
+}
+
 SCENARIO("average sample"){
     printf("//! [average sample]\n");
     auto values = rxcpp::observable<>::range(1, 4).average();
@@ -86,4 +99,20 @@ SCENARIO("average sample"){
             [](double v){printf("OnNext: %lf\n", v);},
             [](){printf("OnCompleted\n");});
     printf("//! [average sample]\n");
+}
+
+SCENARIO("average empty sample"){
+    printf("//! [average empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().average();
+    values.
+        subscribe(
+            [](double v){printf("OnNext: %lf\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [average empty sample]\n");
 }

--- a/Rx/v2/examples/doxygen/math.cpp
+++ b/Rx/v2/examples/doxygen/math.cpp
@@ -21,7 +21,7 @@ SCENARIO("first empty sample"){
             [](int v){printf("OnNext: %d\n", v);},
             [](std::exception_ptr ep){
                 try {std::rethrow_exception(ep);}
-                catch (const std::exception& ex) {
+                catch (const rxcpp::empty_error& ex) {
                     printf("OnError: %s\n", ex.what());
                 }
             },
@@ -47,7 +47,7 @@ SCENARIO("last empty sample"){
             [](int v){printf("OnNext: %d\n", v);},
             [](std::exception_ptr ep){
                 try {std::rethrow_exception(ep);}
-                catch (const std::exception& ex) {
+                catch (const rxcpp::empty_error& ex) {
                     printf("OnError: %s\n", ex.what());
                 }
             },
@@ -63,6 +63,18 @@ SCENARIO("count sample"){
             [](int v){printf("OnNext: %d\n", v);},
             [](){printf("OnCompleted\n");});
     printf("//! [count sample]\n");
+}
+
+SCENARIO("count error sample"){
+    printf("//! [count error sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).
+        concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
+        count();
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](){printf("OnCompleted\n");});
+    printf("//! [count error sample]\n");
 }
 
 SCENARIO("sum sample"){
@@ -83,12 +95,24 @@ SCENARIO("sum empty sample"){
             [](int v){printf("OnNext: %d\n", v);},
             [](std::exception_ptr ep){
                 try {std::rethrow_exception(ep);}
-                catch (const std::exception& ex) {
+                catch (const rxcpp::empty_error& ex) {
                     printf("OnError: %s\n", ex.what());
                 }
             },
             [](){printf("OnCompleted\n");});
     printf("//! [sum empty sample]\n");
+}
+
+SCENARIO("sum error sample"){
+    printf("//! [sum error sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).
+        concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
+        sum();
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](){printf("OnCompleted\n");});
+    printf("//! [sum error sample]\n");
 }
 
 SCENARIO("average sample"){
@@ -109,10 +133,22 @@ SCENARIO("average empty sample"){
             [](double v){printf("OnNext: %lf\n", v);},
             [](std::exception_ptr ep){
                 try {std::rethrow_exception(ep);}
-                catch (const std::exception& ex) {
+                catch (const rxcpp::empty_error& ex) {
                     printf("OnError: %s\n", ex.what());
                 }
             },
             [](){printf("OnCompleted\n");});
     printf("//! [average empty sample]\n");
+}
+
+SCENARIO("average error sample"){
+    printf("//! [average error sample]\n");
+    auto values = rxcpp::observable<>::range(1, 4).
+        concat(rxcpp::observable<>::error<int>(std::runtime_error("Error from source"))).
+        average();
+    values.
+        subscribe(
+            [](double v){printf("OnNext: %lf\n", v);},
+            [](){printf("OnCompleted\n");});
+    printf("//! [average error sample]\n");
 }

--- a/Rx/v2/examples/doxygen/reduce.cpp
+++ b/Rx/v2/examples/doxygen/reduce.cpp
@@ -22,3 +22,23 @@ SCENARIO("reduce sample"){
             [](){printf("OnCompleted\n");});
     printf("//! [reduce sample]\n");
 }
+
+SCENARIO("reduce empty sample"){
+    printf("//! [reduce empty sample]\n");
+    auto values = rxcpp::observable<>::empty<int>().
+        reduce(
+            1,
+            [](int seed, int){return seed;},
+            [](int res){return res;});
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [reduce empty sample]\n");
+}

--- a/Rx/v2/examples/doxygen/reduce.cpp
+++ b/Rx/v2/examples/doxygen/reduce.cpp
@@ -38,7 +38,7 @@ SCENARIO("reduce empty sample"){
 }
 
 SCENARIO("reduce exception from accumulator sample"){
-    printf("//! [reduce exception from accumulator sample] <<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n");
+    printf("//! [reduce exception from accumulator sample]\n");
     auto values = rxcpp::observable<>::range(1, 3).
         reduce(
             0,

--- a/Rx/v2/examples/doxygen/reduce.cpp
+++ b/Rx/v2/examples/doxygen/reduce.cpp
@@ -28,7 +28,25 @@ SCENARIO("reduce empty sample"){
     auto values = rxcpp::observable<>::empty<int>().
         reduce(
             1,
-            [](int seed, int){return seed;},
+            [](int,int){return 0;},
+            [](int res){return res;});
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](){printf("OnCompleted\n");});
+    printf("//! [reduce empty sample]\n");
+}
+
+SCENARIO("reduce exception from accumulator sample"){
+    printf("//! [reduce exception from accumulator sample] <<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n");
+    auto values = rxcpp::observable<>::range(1, 3).
+        reduce(
+            0,
+            [](int seed, int v){
+                if (v == 2)
+                    throw std::runtime_error("Exception from accumulator");
+                return seed;
+            },
             [](int res){return res;});
     values.
         subscribe(
@@ -40,5 +58,28 @@ SCENARIO("reduce empty sample"){
                 }
             },
             [](){printf("OnCompleted\n");});
-    printf("//! [reduce empty sample]\n");
+    printf("//! [reduce exception from accumulator sample]\n");
+}
+
+SCENARIO("reduce exception from result selector sample"){
+    printf("//! [reduce exception from result selector sample]\n");
+    auto values = rxcpp::observable<>::range(1, 3).
+        reduce(
+            0,
+            [](int seed, int v){return seed + v;},
+            [](int res){
+                throw std::runtime_error("Exception from result selector");
+                return res;
+            });
+    values.
+        subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](std::exception_ptr ep){
+                try {std::rethrow_exception(ep);}
+                catch (const std::exception& ex) {
+                    printf("OnError: %s\n", ex.what());
+                }
+            },
+            [](){printf("OnCompleted\n");});
+    printf("//! [reduce exception from result selector sample]\n");
 }

--- a/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
@@ -9,6 +9,14 @@
 
 namespace rxcpp {
 
+class empty_error: public std::runtime_error
+{
+    public:
+        empty_error(const std::string& msg):
+            std::runtime_error(msg)
+        {}
+};
+
 namespace operators {
 
 namespace detail {
@@ -289,14 +297,6 @@ auto reduce(Seed s, Accumulator a, ResultSelector rs)
 }
 
 }
-
-class empty_error: public std::runtime_error
-{
-    public:
-        empty_error(const std::string& msg):
-            std::runtime_error(msg)
-        {}
-};
 
 }
 

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -337,14 +337,7 @@ public:
         \snippet output.txt blocking count error sample
     */
     int count() const {
-        rxu::maybe<T> result;
-        rxu::maybe<std::exception_ptr> error;
-        source.count().as_blocking().subscribe(
-            [&](T v){result.reset(v);},
-            [&](std::exception_ptr ep){error.reset(ep);});
-        if (!error.empty())
-            std::rethrow_exception(error.get());
-        return result.get();
+        return source.count().as_blocking().last();
     }
 
     /*! Return the sum of all items emitted by this blocking_observable, or throw an std::runtime_error exception if it emits no items.

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -305,8 +305,12 @@ public:
     */
     T first() {
         rxu::maybe<T> result;
+        rxu::maybe<std::exception_ptr> error;
         composite_subscription cs;
-        subscribe_with_rethrow(cs, [&](T v){result.reset(v); cs.unsubscribe();});
+        subscribe_with_rethrow(
+            cs,
+            [&](T v){result.reset(v); cs.unsubscribe();},
+            [&](std::exception_ptr){});
         if (result.empty())
             throw rxcpp::empty_error("first() requires a stream with at least one value");
         return result.get();
@@ -332,9 +336,7 @@ public:
         rxu::maybe<std::exception_ptr> error;
         subscribe_with_rethrow(
             [&](T v){result.reset(v);},
-            [&](std::exception_ptr ep){error.reset(ep);});
-        if (!error.empty())
-            std::rethrow_exception(error.get());
+            [&](std::exception_ptr){});
         if (result.empty())
             throw rxcpp::empty_error("last() requires a stream with at least one value");
         return result.get();

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -278,11 +278,7 @@ public:
     }
 
     T first() {
-        rxu::maybe<T> result;
-        composite_subscription cs;
-        subscribe(cs, [&](T v){result.reset(v); cs.unsubscribe();});
-        if (result.empty()) throw std::runtime_error("No elements");
-        return result.get();
+        return source.first().as_blocking().last();
     }
 
     T last() const {

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -1932,6 +1932,10 @@ public:
         Geometric mean of source values:
         \snippet reduce.cpp reduce sample
         \snippet output.txt reduce sample
+
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        \snippet reduce.cpp reduce empty sample
+        \snippet output.txt reduce empty sample
     */
     template<class Seed, class Accumulator, class ResultSelector>
     auto reduce(Seed seed, Accumulator&& a, ResultSelector&& rs) const
@@ -1962,6 +1966,10 @@ public:
         \sample
         \snippet math.cpp first sample
         \snippet output.txt first sample
+
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        \snippet math.cpp first empty sample
+        \snippet output.txt first empty sample
     */
     auto first() const
         -> observable<T>;
@@ -1973,6 +1981,10 @@ public:
         \sample
         \snippet math.cpp last sample
         \snippet output.txt last sample
+
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        \snippet math.cpp last empty sample
+        \snippet output.txt last empty sample
     */
     auto last() const
         -> observable<T>;
@@ -1995,6 +2007,10 @@ public:
         \sample
         \snippet math.cpp sum sample
         \snippet output.txt sum sample
+
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        \snippet math.cpp sum empty sample
+        \snippet output.txt sum empty sample
     */
     auto sum() const
         /// \cond SHOW_SERVICE_MEMBERS
@@ -2011,6 +2027,10 @@ public:
         \sample
         \snippet math.cpp average sample
         \snippet output.txt average sample
+
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        \snippet math.cpp average empty sample
+        \snippet output.txt average empty sample
     */
     auto average() const
         /// \cond SHOW_SERVICE_MEMBERS

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -320,7 +320,7 @@ public:
         if (!error.empty())
             std::rethrow_exception(error.get());
         if (result.empty())
-            throw std::runtime_error("No elements");
+            throw rxcpp::empty_error("No elements");
         return result.get();
     }
 
@@ -328,11 +328,13 @@ public:
 
         \return  The total number of items emitted by this blocking_observable.
 
-        \note  If the source observable calls on_error, the raised exception is rethrown by this method.
-
         \sample
         \snippet blocking_observable.cpp blocking count sample
         \snippet output.txt blocking count sample
+
+        If the source observable calls on_error, the resulting observable behaves like it was on_completed: it emits the number of elements:
+        \snippet blocking_observable.cpp blocking count error sample
+        \snippet output.txt blocking count error sample
     */
     int count() const {
         rxu::maybe<T> result;
@@ -349,8 +351,6 @@ public:
 
         \return  The sum of all items emitted by this blocking_observable.
 
-        \note  If the source observable calls on_error, the raised exception is rethrown by this method.
-
         \sample
         When the source observable emits at least one item:
         \snippet blocking_observable.cpp blocking sum sample
@@ -359,6 +359,10 @@ public:
         When the source observable is empty:
         \snippet blocking_observable.cpp blocking sum empty sample
         \snippet output.txt blocking sum empty sample
+
+        If the source observable calls on_error, the resulting observable behaves like it was on_completed: it emits the average value of elements:
+        \snippet blocking_observable.cpp blocking sum error sample
+        \snippet output.txt blocking sum error sample
     */
     T sum() const {
         return source.sum().as_blocking().last();
@@ -368,8 +372,6 @@ public:
 
         \return  The average value of all items emitted by this blocking_observable.
 
-        \note  If the source observable calls on_error, the raised exception is rethrown by this method.
-
         \sample
         When the source observable emits at least one item:
         \snippet blocking_observable.cpp blocking average sample
@@ -378,6 +380,10 @@ public:
         When the source observable is empty:
         \snippet blocking_observable.cpp blocking average empty sample
         \snippet output.txt blocking average empty sample
+
+        If the source observable calls on_error, the resulting observable behaves like it was on_completed: it emits the average value of elements:
+        \snippet blocking_observable.cpp blocking average error sample
+        \snippet output.txt blocking average error sample
     */
     double average() const {
         return source.average().as_blocking().last();
@@ -2014,9 +2020,17 @@ public:
         \snippet reduce.cpp reduce sample
         \snippet output.txt reduce sample
 
-        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        If the source observable completes without emitting any items, the resulting observable emits the result of passing the initial seed to the result selector:
         \snippet reduce.cpp reduce empty sample
         \snippet output.txt reduce empty sample
+
+        If the accumulator raises an exception, it is returned by the resulting observable in on_error:
+        \snippet reduce.cpp reduce exception from accumulator sample
+        \snippet output.txt reduce exception from accumulator sample
+
+        The same for exceptions raised by the result selector:
+        \snippet reduce.cpp reduce exception from result selector sample
+        \snippet output.txt reduce exception from result selector sample
     */
     template<class Seed, class Accumulator, class ResultSelector>
     auto reduce(Seed seed, Accumulator&& a, ResultSelector&& rs) const
@@ -2077,9 +2091,18 @@ public:
         \sample
         \snippet math.cpp count sample
         \snippet output.txt count sample
+
+        If the source observable calls on_error, the resulting observable behaves like it was on_completed: it emits the number of elements:
+        \snippet math.cpp count error sample
+        \snippet output.txt count error sample
     */
     auto count() const
-        -> observable<int>;
+        /// \cond SHOW_SERVICE_MEMBERS
+        -> typename defer_reduce<int, rxu::count, rxu::defer_type<identity_for, int>>::observable_type
+        /// \endcond
+    {
+        return      defer_reduce<int, rxu::count, rxu::defer_type<identity_for, int>>::make(source_operator, rxu::count(), identity_for<int>(), 0, false);
+    }
 
     /*! For each item from this observable reduce it by adding to the previous items.
 
@@ -2089,16 +2112,20 @@ public:
         \snippet math.cpp sum sample
         \snippet output.txt sum sample
 
-        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers:
         \snippet math.cpp sum empty sample
         \snippet output.txt sum empty sample
+
+        If the source observable calls on_error, the resulting observable behaves like it was on_completed: it emits the sum of elements:
+        \snippet math.cpp sum error sample
+        \snippet output.txt sum error sample
     */
     auto sum() const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> typename defer_reduce<rxu::defer_seed_type<rxo::detail::initialize_seeder, T>, rxu::plus, rxu::defer_type<identity_for, T>>::observable_type
+        -> typename defer_reduce<rxu::defer_seed_type<rxo::detail::sum, T>, rxu::defer_type<rxo::detail::sum, T>, rxu::defer_type<rxo::detail::sum, T>>::observable_type
         /// \endcond
     {
-        return      defer_reduce<rxu::defer_seed_type<rxo::detail::initialize_seeder, T>, rxu::plus, rxu::defer_type<identity_for, T>>::make(source_operator, rxu::plus(), identity_for<T>(), rxo::detail::initialize_seeder<T>().seed());
+        return      defer_reduce<rxu::defer_seed_type<rxo::detail::sum, T>, rxu::defer_type<rxo::detail::sum, T>, rxu::defer_type<rxo::detail::sum, T>>::make(source_operator, rxo::detail::sum<T>(), rxo::detail::sum<T>(), rxo::detail::sum<T>().seed(), false);
     }
 
     /*! For each item from this observable reduce it by adding to the previous values and then dividing by the number of items at the end.
@@ -2109,16 +2136,20 @@ public:
         \snippet math.cpp average sample
         \snippet output.txt average sample
 
-        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers.
+        If the source observable completes without emitting any items, the resulting observable calls on_error method of its observers:
         \snippet math.cpp average empty sample
         \snippet output.txt average empty sample
+
+        If the source observable calls on_error, the resulting observable behaves like it was on_completed: it emits the average value of elements:
+        \snippet math.cpp average error sample
+        \snippet output.txt average error sample
     */
     auto average() const
         /// \cond SHOW_SERVICE_MEMBERS
         -> typename defer_reduce<rxu::defer_seed_type<rxo::detail::average, T>, rxu::defer_type<rxo::detail::average, T>, rxu::defer_type<rxo::detail::average, T>>::observable_type
         /// \endcond
     {
-        return      defer_reduce<rxu::defer_seed_type<rxo::detail::average, T>, rxu::defer_type<rxo::detail::average, T>, rxu::defer_type<rxo::detail::average, T>>::make(source_operator, rxo::detail::average<T>(), rxo::detail::average<T>(), rxo::detail::average<T>().seed());
+        return      defer_reduce<rxu::defer_seed_type<rxo::detail::average, T>, rxu::defer_type<rxo::detail::average, T>, rxu::defer_type<rxo::detail::average, T>>::make(source_operator, rxo::detail::average<T>(), rxo::detail::average<T>(), rxo::detail::average<T>().seed(), false);
     }
 
     /*! For each item from this observable use Accumulator to combine items into a value that will be emitted from the new observable that is returned.
@@ -2476,19 +2507,16 @@ template<class T, class SourceOperator>
 auto observable<T, SourceOperator>::last() const
     -> observable<T> {
     rxu::maybe<T> seed;
-    return this->reduce(seed, [](rxu::maybe<T>, T t){return rxu::maybe<T>(std::move(t));}, [](rxu::maybe<T> result){return result.get();});
+    return this->reduce(
+        seed,
+        [](rxu::maybe<T>, T t){return rxu::maybe<T>(std::move(t));},
+        [](rxu::maybe<T> result){return result.empty() ? throw rxcpp::empty_error("No elements") : result.get();});
 }
 
 template<class T, class SourceOperator>
 auto observable<T, SourceOperator>::first() const
     -> observable<T> {
     return this->take(1).last();
-}
-
-template<class T, class SourceOperator>
-auto observable<T, SourceOperator>::count() const
-    -> observable<int> {
-    return this->reduce(0, [](int current, const T&){return ++current;}, [](int result){return result;});
 }
 
 template<class T, class SourceOperator>
@@ -3115,7 +3143,6 @@ public:
     }
 };
 
-
 }
 
 //
@@ -3137,6 +3164,5 @@ auto operator | (const rxcpp::observable<T, SourceOperator>& source, OperatorFac
     -> decltype(source.op(std::forward<OperatorFactory>(of))) {
     return      source.op(std::forward<OperatorFactory>(of));
 }
-
 
 #endif

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -355,7 +355,11 @@ public:
         \snippet output.txt blocking count error sample
     */
     int count() const {
-        return source.count().as_blocking().last();
+        int result;
+        on_exception(
+            [&](){result = source.count().as_blocking().last(); return true;},
+            [&](std::exception_ptr){result = 0;});
+        return result;
     }
 
     /*! Return the sum of all items emitted by this blocking_observable, or throw an std::runtime_error exception if it emits no items.

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -281,19 +281,23 @@ public:
         rxu::maybe<T> result;
         composite_subscription cs;
         subscribe(cs, [&](T v){result.reset(v); cs.unsubscribe();});
-        if (result.empty()) abort();
+        if (result.empty()) throw std::runtime_error("No elements");
         return result.get();
     }
 
     T last() const {
         rxu::maybe<T> result;
         subscribe([&](T v){result.reset(v);});
-        if (result.empty()) abort();
+        if (result.empty()) throw std::runtime_error("No elements");
         return result.get();
     }
 
     int count() const {
-        return source.count().as_blocking().last();
+        rxu::maybe<T> result;
+        source.count().as_blocking().subscribe(
+            [&](T v){result.reset(v);},
+            [](std::exception_ptr){result.reset(0);});
+        return result.get();
     }
     T sum() const {
         return source.sum().as_blocking().last();

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -114,16 +114,12 @@ template<class... TN> struct types_checked_from {typedef types_checked type;};
 template<class... TN>
 struct types_checked_from {typedef typename detail::types_checked_from<TN...>::type type;};
 
-
-
 template<class T, class C = types_checked>
 struct value_type_from : public std::false_type {typedef types_checked type;};
 
 template<class T>
 struct value_type_from<T, typename types_checked_from<value_type_t<T>>::type>
     : public std::true_type {typedef value_type_t<T> type;};
-
-
 
 namespace detail {
 
@@ -329,6 +325,13 @@ struct plus
     auto operator()(LHS&& lhs, RHS&& rhs) const
         -> decltype(std::forward<LHS>(lhs) + std::forward<RHS>(rhs))
         { return std::forward<LHS>(lhs) + std::forward<RHS>(rhs); }
+};
+
+struct count
+{
+    template <class T>
+    int operator()(int cnt, T&&) const
+    { return cnt + 1; }
 };
 
 struct less

--- a/projects/doxygen/CMakeLists.txt
+++ b/projects/doxygen/CMakeLists.txt
@@ -44,6 +44,7 @@ if(DOXYGEN_FOUND)
         ${DOXY_EXAMPLES_SRC_DIR}/main.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/amb.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/as_dynamic.cpp
+        ${DOXY_EXAMPLES_SRC_DIR}/blocking_observable.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/buffer.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/combine_latest.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/concat.cpp


### PR DESCRIPTION
Implement new behavior of reduce operator:
1. Reducing an empty observable returns result_selector(seed).
2. Exceptions from accumulator() and result_selector() are caught and emitted as on_error().
3. first(), last(), sum(), average() emit rxcpp::empty_error when applied to an empty observable.
4. count() of an empty observable emits 0.
5. If the source observable for count(), sum(), average() calls on_error(), the resulting observable behaves like it was on_completed().