### PR TITLE
add run loop scheduler

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -53,12 +53,16 @@ struct repeat : public operator_base<T>
             }
             composite_subscription source_lifetime;
             output_type out;
+            composite_subscription::weak_subscription lifetime_token;
 
             void do_subscribe() {
                 auto state = this->shared_from_this();
+                
+                state->out.remove(state->lifetime_token);
+                state->source_lifetime.unsubscribe();
 
                 state->source_lifetime = composite_subscription();
-                state->out.add(state->source_lifetime);
+                state->lifetime_token = state->out.add(state->source_lifetime);
 
                 state->source.subscribe(
                     state->out,

--- a/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -329,7 +329,7 @@ inline bool operator==(const worker& lhs, const worker& rhs) {
 inline bool operator!=(const worker& lhs, const worker& rhs) {
     return !(lhs == rhs);
 }
-    
+
 class weak_worker
 {
     detail::worker_interface_weak_ptr inner;
@@ -344,7 +344,7 @@ public:
         , lifetime(owner.lifetime)
     {
     }
-    
+
     worker lock() const {
         return worker(lifetime, inner.lock());
     }
@@ -419,6 +419,9 @@ inline scheduler make_scheduler(ArgN&&... an) {
     return scheduler(std::static_pointer_cast<scheduler_interface>(std::make_shared<Scheduler>(std::forward<ArgN>(an)...)));
 }
 
+inline scheduler make_scheduler(std::shared_ptr<scheduler_interface> si) {
+    return scheduler(si);
+}
 
 class schedulable : public schedulable_base
 {
@@ -912,6 +915,7 @@ namespace rxsc=schedulers;
 }
 
 #include "schedulers/rx-currentthread.hpp"
+#include "schedulers/rx-runloop.hpp"
 #include "schedulers/rx-newthread.hpp"
 #include "schedulers/rx-eventloop.hpp"
 #include "schedulers/rx-immediate.hpp"

--- a/Rx/v2/src/rxcpp/schedulers/rx-runloop.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-runloop.hpp
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+#pragma once
+
+#if !defined(RXCPP_RX_SCHEDULER_RUN_LOOP_HPP)
+#define RXCPP_RX_SCHEDULER_RUN_LOOP_HPP
+
+#include "../rx-includes.hpp"
+
+namespace rxcpp {
+
+namespace schedulers {
+
+namespace detail {
+
+struct run_loop_state : public std::enable_shared_from_this<run_loop_state>
+{
+    typedef scheduler::clock_type clock_type;
+
+    typedef detail::schedulable_queue<
+        clock_type::time_point> queue_item_time;
+
+    typedef queue_item_time::item_type item_type;
+    typedef queue_item_time::const_reference const_reference_item_type;
+
+    virtual ~run_loop_state()
+    {
+    }
+
+    run_loop_state()
+    {
+    }
+
+    composite_subscription lifetime;
+    mutable std::mutex lock;
+    mutable queue_item_time q;
+    recursion r;
+};
+
+}
+
+
+struct run_loop_scheduler : public scheduler_interface
+{
+private:
+    typedef run_loop_scheduler this_type;
+    run_loop_scheduler(const this_type&);
+
+    struct run_loop_worker : public worker_interface
+    {
+    private:
+        typedef run_loop_worker this_type;
+
+        run_loop_worker(const this_type&);
+
+    public:
+        std::weak_ptr<detail::run_loop_state> state;
+
+        virtual ~run_loop_worker()
+        {
+        }
+
+        explicit run_loop_worker(std::weak_ptr<detail::run_loop_state> ws)
+            : state(ws)
+        {
+        }
+
+        virtual clock_type::time_point now() const {
+            return clock_type::now();
+        }
+
+        virtual void schedule(const schedulable& scbl) const {
+            schedule(now(), scbl);
+        }
+
+        virtual void schedule(clock_type::time_point when, const schedulable& scbl) const {
+            if (scbl.is_subscribed()) {
+                auto st = state.lock();
+                std::unique_lock<std::mutex> guard(st->lock);
+                st->q.push(detail::run_loop_state::item_type(when, scbl));
+                st->r.reset(false);
+            }
+        }
+    };
+
+    std::weak_ptr<detail::run_loop_state> state;
+
+public:
+    explicit run_loop_scheduler(std::weak_ptr<detail::run_loop_state> ws)
+        : state(ws)
+    {
+    }
+    virtual ~run_loop_scheduler()
+    {
+    }
+
+    virtual clock_type::time_point now() const {
+        return clock_type::now();
+    }
+
+    virtual worker create_worker(composite_subscription cs) const {
+        auto lifetime = state.lock()->lifetime;
+        auto token = lifetime.add(cs);
+        cs.add([=](){lifetime.remove(token);});
+        return worker(cs, create_worker_interface());
+    }
+
+    std::shared_ptr<worker_interface> create_worker_interface() const {
+        return std::make_shared<run_loop_worker>(state);
+    }
+};
+
+class run_loop
+{
+private:
+    typedef run_loop this_type;
+    // don't allow this instance to copy/move since it owns current_thread queue
+    // for the thread it is constructed on.
+    run_loop(const this_type&);
+    run_loop(this_type&&);
+
+    typedef scheduler::clock_type clock_type;
+    typedef detail::action_queue queue_type;
+
+    typedef detail::run_loop_state::item_type item_type;
+    typedef detail::run_loop_state::const_reference_item_type const_reference_item_type;
+
+    std::shared_ptr<detail::run_loop_state> state;
+    std::shared_ptr<run_loop_scheduler> sc;
+
+public:
+    run_loop()
+        : state(std::make_shared<detail::run_loop_state>())
+        , sc(std::make_shared<run_loop_scheduler>(state))
+    {
+        // take ownership so that the current_thread scheduler
+        // uses the same queue on this thread
+        queue_type::ensure(sc->create_worker_interface());
+    }
+    ~run_loop()
+    {
+        state->lifetime.unsubscribe();
+
+        std::unique_lock<std::mutex> guard(state->lock);
+
+        // release ownership
+        queue_type::destroy();
+
+        auto expired = std::move(state->q);
+        if (!state->q.empty()) abort();
+    }
+
+    clock_type::time_point now() const {
+        return clock_type::now();
+    }
+    
+    composite_subscription get_subscription() const {
+        return state->lifetime;
+    }
+    
+    bool empty() const {
+        return state->q.empty();
+    }
+
+    const_reference_item_type peek() const {
+        return state->q.top();
+    }
+
+    void dispatch() const {
+        std::unique_lock<std::mutex> guard(state->lock);
+        if (state->q.empty()) {
+            return;
+        }
+        auto& peek = state->q.top();
+        if (!peek.what.is_subscribed()) {
+            state->q.pop();
+            return;
+        }
+        if (clock_type::now() < peek.when) {
+            return;
+        }
+        auto what = peek.what;
+        state->q.pop();
+        state->r.reset(state->q.empty());
+        guard.unlock();
+        what(state->r.get_recurse());
+    }
+
+    scheduler get_scheduler() const {
+        return make_scheduler(sc);
+    }
+};
+
+inline scheduler make_run_loop(const run_loop& r) {
+    return r.get_scheduler();
+}
+
+}
+
+}
+
+#endif

--- a/Rx/v2/test/operators/observe_on.cpp
+++ b/Rx/v2/test/operators/observe_on.cpp
@@ -10,7 +10,7 @@ namespace rxsub=rxcpp::subjects;
 
 const int static_onnextcalls = 100000;
 
-SCENARIO("range observed on current_thread", "[hide][range][observe_on_debug][observe_on][long][perf]"){
+SCENARIO("range observed on new_thread", "[hide][range][observe_on_debug][observe_on][long][perf]"){
     const int& onnextcalls = static_onnextcalls;
     GIVEN("a range"){
         WHEN("multicasting a million ints"){
@@ -35,6 +35,7 @@ SCENARIO("range observed on current_thread", "[hide][range][observe_on_debug][ob
                 rxs::range<int>(1)
                     .take(onnextcalls)
                     .observe_on(el)
+                    .as_blocking()
                     .subscribe(
                         cs,
                         [c](int){
@@ -43,12 +44,11 @@ SCENARIO("range observed on current_thread", "[hide][range][observe_on_debug][ob
                         [&](){
                             done = true;
                         });
-                while(!done || !disposed);
                 auto expected = onnextcalls;
                 REQUIRE(*c == expected);
                 auto finish = clock::now();
                 auto msElapsed = duration_cast<milliseconds>(finish-start);
-                std::cout << "range -> observe_on current_thread : " << (*c) << " on_next calls, " << msElapsed.count() << "ms elapsed, int-per-second " << *c / (msElapsed.count() / 1000.0) << std::endl;
+                std::cout << "range -> observe_on new_thread : " << (*c) << " on_next calls, " << msElapsed.count() << "ms elapsed, int-per-second " << *c / (msElapsed.count() / 1000.0) << std::endl;
             }
         }
     }

--- a/Rx/v2/test/subjects/subject.cpp
+++ b/Rx/v2/test/subjects/subject.cpp
@@ -13,7 +13,7 @@ namespace rxsub=rxcpp::subjects;
 #include <future>
 
 
-const int static_onnextcalls = 100000000;
+const int static_onnextcalls = 10000000;
 static int aliased = 0;
 
 SCENARIO("for loop locks mutex", "[hide][for][mutex][long][perf]"){
@@ -33,7 +33,7 @@ SCENARIO("for loop locks mutex", "[hide][for][mutex][long][perf]"){
             }
             auto finish = clock::now();
             auto msElapsed = duration_cast<milliseconds>(finish-start);
-            std::cout << "loop mutex          : " << n << " subscribed, " << c << " on_next calls, " << msElapsed.count() << "ms elapsed " << std::endl;
+            std::cout << "loop mutex          : " << n << " subscribed, " << c << " on_next calls, " << msElapsed.count() << "ms elapsed " << c / (msElapsed.count() / 1000.0) << " ops/sec" << std::endl;
 
         }
     }
@@ -76,7 +76,7 @@ SCENARIO("for loop calls void on_next(int)", "[hide][for][asyncobserver][baselin
             }
             auto finish = clock::now();
             auto msElapsed = duration_cast<milliseconds>(finish-start);
-            std::cout << "loop void           : " << n << " subscribed, " << *c << " on_next calls, " << msElapsed.count() << "ms elapsed " << std::endl;
+            std::cout << "loop void           : " << n << " subscribed, " << *c << " on_next calls, " << msElapsed.count() << "ms elapsed " << *c / (msElapsed.count() / 1000.0) << " ops/sec" << std::endl;
 
         }
     }
@@ -170,7 +170,7 @@ SCENARIO("for loop calls ready on_next(int)", "[hide][for][asyncobserver][ready]
             chunk();
             auto finish = clock::now();
             auto msElapsed = duration_cast<milliseconds>(finish-start);
-            std::cout << "loop ready          : " << n << " subscribed, " << *c << " on_next calls, " << msElapsed.count() << "ms elapsed " << std::endl;
+            std::cout << "loop ready          : " << n << " subscribed, " << *c << " on_next calls, " << msElapsed.count() << "ms elapsed " << *c / (msElapsed.count() / 1000.0) << " ops/sec" << std::endl;
 
         }
     }
@@ -218,7 +218,7 @@ SCENARIO("for loop calls std::future<unit> on_next(int)", "[hide][for][asyncobse
             }
             auto finish = clock::now();
             auto msElapsed = duration_cast<milliseconds>(finish-start);
-            std::cout << "loop future<unit>   : " << n << " subscribed, " << *c << " on_next calls, " << msElapsed.count() << "ms elapsed " << std::endl;
+            std::cout << "loop future<unit>   : " << n << " subscribed, " << *c << " on_next calls, " << msElapsed.count() << "ms elapsed " << *c / (msElapsed.count() / 1000.0) << " ops/sec" << std::endl;
 
         }
     }
@@ -245,7 +245,7 @@ SCENARIO("for loop calls observer", "[hide][for][observer][perf]"){
             o.on_completed();
             auto finish = clock::now();
             auto msElapsed = duration_cast<milliseconds>(finish-start);
-            std::cout << "loop -> observer    : " << n << " subscribed, " << c << " on_next calls, " << msElapsed.count() << "ms elapsed " << std::endl;
+            std::cout << "loop -> observer    : " << n << " subscribed, " << c << " on_next calls, " << msElapsed.count() << "ms elapsed " << c / (msElapsed.count() / 1000.0) << " ops/sec"<< std::endl;
         }
     }
 }
@@ -271,7 +271,7 @@ SCENARIO("for loop calls subscriber", "[hide][for][subscriber][perf]"){
             o.on_completed();
             auto finish = clock::now();
             auto msElapsed = duration_cast<milliseconds>(finish-start);
-            std::cout << "loop -> subscriber  : " << n << " subscribed, " << c << " on_next calls, " << msElapsed.count() << "ms elapsed " << std::endl;
+            std::cout << "loop -> subscriber  : " << n << " subscribed, " << c << " on_next calls, " << msElapsed.count() << "ms elapsed " << c / (msElapsed.count() / 1000.0) << " ops/sec" << std::endl;
         }
     }
 }
@@ -297,7 +297,7 @@ SCENARIO("range calls subscriber", "[hide][range][subscriber][perf]"){
 
             auto finish = clock::now();
             auto msElapsed = duration_cast<milliseconds>(finish-start);
-            std::cout << "range -> subscriber : " << n << " subscribed, " << c << " on_next calls, " << msElapsed.count() << "ms elapsed " << std::endl;
+            std::cout << "range -> subscriber : " << n << " subscribed, " << c << " on_next calls, " << msElapsed.count() << "ms elapsed " << c / (msElapsed.count() / 1000.0) << " ops/sec" << std::endl;
         }
     }
 }
@@ -362,7 +362,7 @@ SCENARIO("for loop calls subject", "[hide][for][subject][subjects][long][perf]")
                 o.on_completed();
                 auto finish = clock::now();
                 auto msElapsed = duration_cast<milliseconds>(finish-start);
-                std::cout << "loop -> subject     : " << n << " subscribed, " << (*c) << " on_next calls, " << msElapsed.count() << "ms elapsed " << std::endl;
+                std::cout << "loop -> subject     : " << n << " subscribed, " << (*c) << " on_next calls, " << msElapsed.count() << "ms elapsed " << *c / (msElapsed.count() / 1000.0) << " ops/sec" << std::endl;
             }
         }
     }
@@ -426,7 +426,7 @@ SCENARIO("range calls subject", "[hide][range][subject][subjects][long][perf]"){
                     .subscribe(o);
                 auto finish = clock::now();
                 auto msElapsed = duration_cast<milliseconds>(finish-start);
-                std::cout << "range -> subject    : " << n << " subscribed, " << (*c) << " on_next calls, " << msElapsed.count() << "ms elapsed " << std::endl;
+                std::cout << "range -> subject    : " << n << " subscribed, " << (*c) << " on_next calls, " << msElapsed.count() << "ms elapsed " << *c / (msElapsed.count() / 1000.0) << " ops/sec"<< std::endl;
             }
         }
     }

--- a/Rx/v2/test/subscriptions/subscription.cpp
+++ b/Rx/v2/test/subscriptions/subscription.cpp
@@ -21,7 +21,7 @@ SCENARIO("observe subscription", "[hide]"){
     }
 }
 
-static const int static_subscriptions = 100000;
+static const int static_subscriptions = 10000;
 
 SCENARIO("for loop subscribes to map", "[hide][for][just][subscribe][long][perf]"){
     const int& subscriptions = static_subscriptions;

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -85,6 +85,7 @@ set(RX_SOURCES
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/schedulers/rx-eventloop.hpp
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/schedulers/rx-immediate.hpp
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp
+   ${RXCPP_DIR}/Rx/v2/src/rxcpp/schedulers/rx-runloop.hpp
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/schedulers/rx-sameworker.hpp
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/schedulers/rx-virtualtime.hpp


### PR DESCRIPTION
I added the run loop scheduler to answer #151 

## Usage

```cpp
#include "rxcpp/rx.hpp"
// create alias' to simplify code
// these are owned by the user so that
// conflicts can be managed by the user.
namespace rx=rxcpp;

int main()
{
    std::cout << std::setw(16) << std::this_thread::get_id() << " <- main thread id" << std::endl;

    using namespace std::chrono;

    rx::schedulers::run_loop rl;

    auto mainthread = rx::observe_on_run_loop(rl);
    auto workthread = rx::synchronize_new_thread();

    rx::composite_subscription lifetime;

    rx::observable<>::interval(workthread.now() + milliseconds(100), milliseconds(400)).
        map([](int i){
            std::cout << std::setw(16) << std::this_thread::get_id() << ": " << i << std::endl;
            return i;
        }).
        take_until(rx::observable<>::timer(seconds(1))).
        subscribe_on(workthread).
        observe_on(mainthread).
        subscribe(lifetime, [&](int i){
            std::cout << std::setw(16) << std::this_thread::get_id() << ": " << i << std::endl;
        });

    while (lifetime.is_subscribed() || !rl.empty()) {
        while (!rl.empty() && rl.peek().when < rl.now()) {
            rl.dispatch();
        }
    }
    return 0;
}
```

## Output:

```sh
  0x7fff7b1cb300 <- main thread id
     0x102047000: 1
  0x7fff7b1cb300: 1
     0x102047000: 2
  0x7fff7b1cb300: 2
     0x102047000: 3
  0x7fff7b1cb300: 3
```