### PR TITLE
Fix gcc 4.9 error - invalid use of non-lvalue array

### DIFF
--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -341,7 +341,7 @@ struct print_function
     template<class... TN>
     void operator()(const TN&... tn) const {
         bool inserts[] = {(os << tn, true)...};
-        inserts[0] = *(inserts); // silence warning
+        inserts[0] = *reinterpret_cast<bool*>(inserts); // silence warning
         delimit();
     }
 


### PR DESCRIPTION
Not sure if I'm doing to merge and pull requests correctly.  In case I've messed up something, please let me know and I'll fix it.