### PR TITLE
new observer

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-observe_on.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-observe_on.hpp
@@ -32,7 +32,6 @@ struct observe_on
     struct observe_on_observer
     {
         typedef observe_on_observer<Subscriber> this_type;
-        typedef observer_base<source_value_type> base_type;
         typedef source_value_type value_type;
         typedef rxu::decay_t<Subscriber> dest_type;
         typedef observer<value_type, this_type> observer_type;
@@ -68,7 +67,7 @@ struct observe_on
                 , destination(std::move(d))
             {
             }
-            
+
             void finish(std::unique_lock<std::mutex>& guard, typename mode::type end) const {
                 if (!guard.owns_lock()) {
                     abort();
@@ -91,13 +90,13 @@ struct observe_on
                 }
                 if (current == mode::Empty) {
                     current = mode::Processing;
-                    
+
                     if (!lifetime.is_subscribed() && fill_queue.empty() && drain_queue.empty()) {
                         finish(guard, mode::Disposed);
                     }
 
                     auto keepAlive = this->shared_from_this();
-                    
+
                     auto drain = [keepAlive, this](const rxsc::schedulable& self){
                         using std::swap;
                         try {
@@ -140,7 +139,7 @@ struct observe_on
                     }
 
                     auto processor = coordinator.get_worker();
-                    
+
                     RXCPP_UNWIND_AUTO([&](){guard.lock();});
                     guard.unlock();
 

--- a/Rx/v2/src/rxcpp/operators/rx-window.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window.hpp
@@ -36,11 +36,10 @@ struct window
     }
 
     template<class Subscriber>
-    struct window_observer : public window_values, public observer_base<observable<T>>
+    struct window_observer : public window_values
     {
         typedef window_observer<Subscriber> this_type;
-        typedef observer_base<observable<T>> base_type;
-        typedef typename base_type::value_type value_type;
+        typedef rxu::decay_t<T> value_type;
         typedef rxu::decay_t<Subscriber> dest_type;
         typedef observer<T, this_type> observer_type;
         dest_type dest;

--- a/Rx/v2/src/rxcpp/operators/rx-window_time.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_time.hpp
@@ -41,11 +41,10 @@ struct window_with_time
     }
 
     template<class Subscriber>
-    struct window_with_time_observer : public observer_base<observable<T>>
+    struct window_with_time_observer
     {
         typedef window_with_time_observer<Subscriber> this_type;
-        typedef observer_base<observable<T>> base_type;
-        typedef typename base_type::value_type value_type;
+        typedef rxu::decay_t<T> value_type;
         typedef rxu::decay_t<Subscriber> dest_type;
         typedef observer<T, this_type> observer_type;
 

--- a/Rx/v2/src/rxcpp/operators/rx-window_time_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_time_count.hpp
@@ -41,11 +41,10 @@ struct window_with_time_or_count
     }
 
     template<class Subscriber>
-    struct window_with_time_or_count_observer : public observer_base<observable<T>>
+    struct window_with_time_or_count_observer
     {
         typedef window_with_time_or_count_observer<Subscriber> this_type;
-        typedef observer_base<observable<T>> base_type;
-        typedef typename base_type::value_type value_type;
+        typedef rxu::decay_t<T> value_type;
         typedef rxu::decay_t<Subscriber> dest_type;
         typedef observer<T, this_type> observer_type;
 

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -40,6 +40,77 @@ struct OnCompletedEmpty
     void operator()() const {}
 };
 
+template<class T, class State, class OnNext>
+struct OnNextForward
+{
+    using state_t = rxu::decay_t<State>;
+    using onnext_t = rxu::decay_t<OnNext>;
+    OnNextForward() : onnext() {}
+    explicit OnNextForward(onnext_t on) : onnext(std::move(on)) {}
+    onnext_t onnext;
+    void operator()(state_t& s, T& t) const {
+        onnext(s, t);
+    }
+    void operator()(state_t& s, T&& t) const {
+        onnext(s, t);
+    }
+};
+template<class T, class State>
+struct OnNextForward<T, State, void>
+{
+    using state_t = rxu::decay_t<State>;
+    OnNextForward() {}
+    void operator()(state_t& s, T& t) const {
+        s.on_next(t);
+    }
+    void operator()(state_t& s, T&& t) const {
+        s.on_next(t);
+    }
+};
+
+template<class State, class OnError>
+struct OnErrorForward
+{
+    using state_t = rxu::decay_t<State>;
+    using onerror_t = rxu::decay_t<OnError>;
+    OnErrorForward() : onerror() {}
+    explicit OnErrorForward(onerror_t oe) : onerror(std::move(oe)) {}
+    onerror_t onerror;
+    void operator()(state_t& s, std::exception_ptr ep) const {
+        onerror(s, ep);
+    }
+};
+template<class State>
+struct OnErrorForward<State, void>
+{
+    using state_t = rxu::decay_t<State>;
+    OnErrorForward() {}
+    void operator()(state_t& s, std::exception_ptr ep) const {
+        s.on_error(ep);
+    }
+};
+
+template<class State, class OnCompleted>
+struct OnCompletedForward
+{
+    using state_t = rxu::decay_t<State>;
+    using oncompleted_t = rxu::decay_t<OnCompleted>;
+    OnCompletedForward() : oncompleted() {}
+    explicit OnCompletedForward(oncompleted_t oc) : oncompleted(std::move(oc)) {}
+    oncompleted_t oncompleted;
+    void operator()(state_t& s) const {
+        oncompleted(s);
+    }
+};
+template<class State>
+struct OnCompletedForward<State, void>
+{
+    OnCompletedForward() {}
+    void operator()(State& s) const {
+        s.on_completed();
+    }
+};
+
 template<class T, class F>
 struct is_on_next_of
 {
@@ -65,6 +136,18 @@ struct is_on_error
     static const bool value = std::is_same<decltype(check<rxu::decay_t<F>>(0)), void>::value;
 };
 
+template<class State, class F>
+struct is_on_error_for
+{
+    struct not_void {};
+    template<class CF>
+    static auto check(int) -> decltype((*(CF*)nullptr)(*(State*)nullptr, *(std::exception_ptr*)nullptr));
+    template<class CF>
+    static not_void check(...);
+
+    static const bool value = std::is_same<decltype(check<rxu::decay_t<F>>(0)), void>::value;
+};
+
 template<class F>
 struct is_on_completed
 {
@@ -79,14 +162,127 @@ struct is_on_completed
 
 }
 
-template<class T, class OnNext, class OnError = detail::OnErrorEmpty, class OnCompleted = detail::OnCompletedEmpty>
-class static_observer
+
+/*!
+    \brief consumes values from an observable using `State` that may implement on_next, on_error and on_completed with optional overrides of each function.
+
+    \tparam T            - the type of value in the stream
+    \tparam State        - the type of the stored state
+    \tparam OnNext       - the type of a function that matches `void(State&, T)`. Called 0 or more times. If `void` State::on_next will be called.
+    \tparam OnError      - the type of a function that matches `void(State&, std::exception_ptr)`. Called 0 or 1 times, no further calls will be made. If `void` State::on_error will be called.
+    \tparam OnCompleted  - the type of a function that matches `void(State&)`. Called 0 or 1 times, no further calls will be made. If `void` State::on_completed will be called.
+
+    \ingroup group-core
+
+*/
+template<class T, class State, class OnNext, class OnError, class OnCompleted>
+class observer : public observer_base<T>
 {
 public:
-    typedef static_observer<T, OnNext, OnError, OnCompleted> this_type;
-    typedef rxu::decay_t<OnNext> on_next_t;
-    typedef rxu::decay_t<OnError> on_error_t;
-    typedef rxu::decay_t<OnCompleted> on_completed_t;
+    using this_type = observer<T, State, OnNext, OnError, OnCompleted>;
+    using state_t = rxu::decay_t<State>;
+    using on_next_t = typename std::conditional<
+        !std::is_same<void, OnNext>::value,
+        rxu::decay_t<OnNext>,
+        detail::OnNextForward<T, State, OnNext>>::type;
+    using on_error_t = typename std::conditional<
+        !std::is_same<void, OnError>::value,
+        rxu::decay_t<OnError>,
+        detail::OnErrorForward<State, OnError>>::type;
+    using on_completed_t = typename std::conditional<
+        !std::is_same<void, OnCompleted>::value,
+        rxu::decay_t<OnCompleted>,
+        detail::OnCompletedForward<State, OnCompleted>>::type;
+
+private:
+    mutable state_t state;
+    on_next_t onnext;
+    on_error_t onerror;
+    on_completed_t oncompleted;
+
+public:
+
+    explicit observer(state_t s, on_next_t n = on_next_t(), on_error_t e = on_error_t(), on_completed_t c = on_completed_t())
+        : state(std::move(s))
+        , onnext(std::move(n))
+        , onerror(std::move(e))
+        , oncompleted(std::move(c))
+    {
+    }
+    explicit observer(state_t s, on_next_t n, on_completed_t c)
+        : state(std::move(s))
+        , onnext(std::move(n))
+        , onerror(on_error_t())
+        , oncompleted(std::move(c))
+    {
+    }
+    observer(const this_type& o)
+        : state(o.state)
+        , onnext(o.onnext)
+        , onerror(o.onerror)
+        , oncompleted(o.oncompleted)
+    {
+    }
+    observer(this_type&& o)
+        : state(std::move(o.state))
+        , onnext(std::move(o.onnext))
+        , onerror(std::move(o.onerror))
+        , oncompleted(std::move(o.oncompleted))
+    {
+    }
+    this_type& operator=(this_type o) {
+        state = std::move(o.state);
+        onnext = std::move(o.onnext);
+        onerror = std::move(o.onerror);
+        oncompleted = std::move(o.oncompleted);
+        return *this;
+    }
+
+    void on_next(T& t) const {
+        onnext(state, t);
+    }
+    void on_next(T&& t) const {
+        onnext(state, std::move(t));
+    }
+    void on_error(std::exception_ptr e) const {
+        onerror(state, e);
+    }
+    void on_completed() const {
+        oncompleted(state);
+    }
+    observer<T> as_dynamic() const {
+        return observer<T>(*this);
+    }
+};
+
+/*!
+    \brief consumes values from an observable using default empty method implementations with optional overrides of each function.
+
+    \tparam T            - the type of value in the stream
+    \tparam OnNext       - the type of a function that matches `void(T)`. Called 0 or more times. If `void` OnNextEmpty<T> is used.
+    \tparam OnError      - the type of a function that matches `void(std::exception_ptr)`. Called 0 or 1 times, no further calls will be made. If `void` OnErrorEmpty is used.
+    \tparam OnCompleted  - the type of a function that matches `void()`. Called 0 or 1 times, no further calls will be made. If `void` OnCompletedEmpty is used.
+
+    \ingroup group-core
+
+*/
+template<class T, class OnNext, class OnError, class OnCompleted>
+class observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted> : public observer_base<T>
+{
+public:
+    using this_type = observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>;
+    using on_next_t = typename std::conditional<
+        !std::is_same<void, OnNext>::value,
+        rxu::decay_t<OnNext>,
+        detail::OnNextEmpty<T>>::type;
+    using on_error_t = typename std::conditional<
+        !std::is_same<void, OnError>::value,
+        rxu::decay_t<OnError>,
+        detail::OnErrorEmpty>::type;
+    using on_completed_t = typename std::conditional<
+        !std::is_same<void, OnCompleted>::value,
+        rxu::decay_t<OnCompleted>,
+        detail::OnCompletedEmpty>::type;
 
 private:
     on_next_t onnext;
@@ -98,19 +294,26 @@ public:
     static_assert(detail::is_on_error<on_error_t>::value,         "Function supplied for on_error must be a function with the signature void(std::exception_ptr);");
     static_assert(detail::is_on_completed<on_completed_t>::value, "Function supplied for on_completed must be a function with the signature void();");
 
-    explicit static_observer(on_next_t n, on_error_t e = on_error_t(), on_completed_t c = on_completed_t())
+    observer()
+        : onnext(on_next_t())
+        , onerror(on_error_t())
+        , oncompleted(on_completed_t())
+    {
+    }
+
+    explicit observer(on_next_t n, on_error_t e = on_error_t(), on_completed_t c = on_completed_t())
         : onnext(std::move(n))
         , onerror(std::move(e))
         , oncompleted(std::move(c))
     {
     }
-    static_observer(const this_type& o)
+    observer(const this_type& o)
         : onnext(o.onnext)
         , onerror(o.onerror)
         , oncompleted(o.oncompleted)
     {
     }
-    static_observer(this_type&& o)
+    observer(this_type&& o)
         : onnext(std::move(o.onnext))
         , onerror(std::move(o.onerror))
         , oncompleted(std::move(o.oncompleted))
@@ -123,10 +326,11 @@ public:
         return *this;
     }
 
-    // use V so that std::move can be used safely
-    template<class V>
-    void on_next(V v) const {
-        onnext(std::move(v));
+    void on_next(T& t) const {
+        onnext(t);
+    }
+    void on_next(T&& t) const {
+        onnext(std::move(t));
     }
     void on_error(std::exception_ptr e) const {
         onerror(e);
@@ -134,69 +338,91 @@ public:
     void on_completed() const {
         oncompleted();
     }
+    observer<T> as_dynamic() const {
+        return observer<T>(*this);
+    }
 };
 
+namespace detail
+{
+
 template<class T>
-class dynamic_observer
+struct virtual_observer : public std::enable_shared_from_this<virtual_observer<T>>
+{
+    virtual ~virtual_observer() {}
+    virtual void on_next(T&) const {};
+    virtual void on_next(T&&) const {};
+    virtual void on_error(std::exception_ptr) const {};
+    virtual void on_completed() const {};
+};
+
+template<class T, class Observer>
+struct specific_observer : public virtual_observer<T>
+{
+    explicit specific_observer(Observer o)
+        : destination(std::move(o))
+    {
+    }
+
+    Observer destination;
+    virtual void on_next(T& t) const {
+        destination.on_next(t);
+    }
+    virtual void on_next(T&& t) const {
+        destination.on_next(std::move(t));
+    }
+    virtual void on_error(std::exception_ptr e) const {
+        destination.on_error(e);
+    }
+    virtual void on_completed() const {
+        destination.on_completed();
+    }
+};
+
+}
+
+/*!
+    \brief consumes values from an observable using type-forgetting (shared allocated state with virtual methods)
+
+    \tparam T            - the type of value in the stream
+
+    \ingroup group-core
+
+*/
+template<class T>
+class observer<T, void, void, void, void> : public observer_base<T>
 {
 public:
     typedef tag_dynamic_observer dynamic_observer_tag;
 
 private:
-    typedef dynamic_observer<T> this_type;
-    typedef observer_base<T> base_type;
-
-    struct virtual_observer : public std::enable_shared_from_this<virtual_observer>
-    {
-        virtual ~virtual_observer() {}
-        virtual void on_next(T) const {};
-        virtual void on_error(std::exception_ptr) const {};
-        virtual void on_completed() const {};
-    };
-
-    template<class Observer>
-    struct specific_observer : public virtual_observer
-    {
-        explicit specific_observer(Observer o)
-            : destination(std::move(o))
-        {
-        }
-
-        Observer destination;
-        virtual void on_next(T t) const {
-            destination.on_next(std::move(t));
-        }
-        virtual void on_error(std::exception_ptr e) const {
-            destination.on_error(e);
-        }
-        virtual void on_completed() const {
-            destination.on_completed();
-        }
-    };
+    using this_type = observer<T, void, void, void, void>;
+    using base_type = observer_base<T>;
+    using virtual_observer = detail::virtual_observer<T>;
 
     std::shared_ptr<virtual_observer> destination;
 
     template<class Observer>
     static auto make_destination(Observer o)
         -> std::shared_ptr<virtual_observer> {
-        return std::make_shared<specific_observer<Observer>>(std::move(o));
+        return std::make_shared<detail::specific_observer<T, Observer>>(std::move(o));
     }
 
 public:
-    dynamic_observer()
+    observer()
     {
     }
-    dynamic_observer(const this_type& o)
+    observer(const this_type& o)
         : destination(o.destination)
     {
     }
-    dynamic_observer(this_type&& o)
+    observer(this_type&& o)
         : destination(std::move(o.destination))
     {
     }
 
     template<class Observer>
-    explicit dynamic_observer(Observer o)
+    explicit observer(Observer o)
         : destination(make_destination(std::move(o)))
     {
     }
@@ -223,84 +449,31 @@ public:
             destination->on_completed();
         }
     }
-};
 
-/*!
-    \brief consumes values from an observable.
-
-    \ingroup group-core
-
-*/
-template<class T, class I>
-class observer : public observer_base<T>
-{
-    typedef observer<T, I> this_type;
-    typedef rxu::decay_t<I> inner_t;
-
-    inner_t inner;
-
-    observer();
-public:
-    ~observer()
-    {
-    }
-    observer(const this_type& o)
-        : inner(o.inner)
-    {
-    }
-    observer(this_type&& o)
-        : inner(std::move(o.inner))
-    {
-    }
-    explicit observer(inner_t inner)
-        : inner(std::move(inner))
-    {
-    }
-    this_type& operator=(this_type o) {
-        inner = std::move(o.inner);
-        return *this;
-    }
-    template<class V>
-    void on_next(V&& v) const {
-        inner.on_next(std::forward<V>(v));
-    }
-    void on_error(std::exception_ptr e) const {
-        inner.on_error(e);
-    }
-    void on_completed() const {
-        inner.on_completed();
-    }
     observer<T> as_dynamic() const {
-        return observer<T>(dynamic_observer<T>(inner));
-    }
-};
-template<class T>
-class observer<T, void> : public observer_base<T>
-{
-    typedef observer this_type;
-public:
-    observer()
-    {
-    }
-    template<class V>
-    void on_next(V&&) const {
-    }
-    void on_error(std::exception_ptr) const {
-    }
-    void on_completed() const {
+        return *this;
     }
 };
 
 template<class T, class DefaultOnError = detail::OnErrorEmpty>
 auto make_observer()
-    ->     observer<T, void> {
-    return observer<T, void>();
+    ->      observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>, DefaultOnError> {
+    return  observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>, DefaultOnError>();
 }
 
-template<class T, class DefaultOnError = detail::OnErrorEmpty, class U, class I>
-auto make_observer(observer<U, I> o)
-    ->      observer<T, I> {
-    return  observer<T, I>(std::move(o));
+template<class T, class DefaultOnError = detail::OnErrorEmpty, class U, class State, class OnNext, class OnError, class OnCompleted>
+auto make_observer(observer<U, State, OnNext, OnError, OnCompleted> o)
+    ->      observer<T, State, OnNext, OnError, OnCompleted> {
+    return  observer<T, State, OnNext, OnError, OnCompleted>(std::move(o));
+}
+template<class T, class DefaultOnError = detail::OnErrorEmpty, class Observer>
+auto make_observer(Observer ob)
+    -> typename std::enable_if<
+        !detail::is_on_next_of<T, Observer>::value &&
+        !detail::is_on_error<Observer>::value &&
+        is_observer<Observer>::value,
+            Observer>::type {
+    return  std::move(ob);
 }
 template<class T, class DefaultOnError = detail::OnErrorEmpty, class Observer>
 auto make_observer(Observer ob)
@@ -315,35 +488,35 @@ template<class T, class DefaultOnError = detail::OnErrorEmpty, class OnNext>
 auto make_observer(OnNext on)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value,
-            observer<T, static_observer<T, OnNext, DefaultOnError>>>::type {
-    return  observer<T, static_observer<T, OnNext, DefaultOnError>>(
-                        static_observer<T, OnNext, DefaultOnError>(std::move(on)));
+            observer<T, detail::stateless_observer_tag, OnNext, DefaultOnError>>::type {
+    return  observer<T, detail::stateless_observer_tag, OnNext, DefaultOnError>(
+                        std::move(on));
 }
 template<class T, class DefaultOnError = detail::OnErrorEmpty, class OnError>
 auto make_observer(OnError oe)
     -> typename std::enable_if<
         detail::is_on_error<OnError>::value,
-            observer<T, static_observer<T, detail::OnNextEmpty<T>, OnError>>>::type {
-    return  observer<T, static_observer<T, detail::OnNextEmpty<T>, OnError>>(
-                        static_observer<T, detail::OnNextEmpty<T>, OnError>(detail::OnNextEmpty<T>(), std::move(oe)));
+            observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>, OnError>>::type {
+    return  observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>, OnError>(
+                        detail::OnNextEmpty<T>(), std::move(oe));
 }
 template<class T, class DefaultOnError = detail::OnErrorEmpty, class OnNext, class OnError>
 auto make_observer(OnNext on, OnError oe)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value,
-            observer<T, static_observer<T, OnNext, OnError>>>::type {
-    return  observer<T, static_observer<T, OnNext, OnError>>(
-                        static_observer<T, OnNext, OnError>(std::move(on), std::move(oe)));
+            observer<T, detail::stateless_observer_tag, OnNext, OnError>>::type {
+    return  observer<T, detail::stateless_observer_tag, OnNext, OnError>(
+                        std::move(on), std::move(oe));
 }
 template<class T, class DefaultOnError = detail::OnErrorEmpty, class OnNext, class OnCompleted>
 auto make_observer(OnNext on, OnCompleted oc)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            observer<T, static_observer<T, OnNext, DefaultOnError, OnCompleted>>>::type {
-    return  observer<T, static_observer<T, OnNext, DefaultOnError, OnCompleted>>(
-                        static_observer<T, OnNext, DefaultOnError, OnCompleted>(std::move(on), DefaultOnError(), std::move(oc)));
+            observer<T, detail::stateless_observer_tag, OnNext, DefaultOnError, OnCompleted>>::type {
+    return  observer<T, detail::stateless_observer_tag, OnNext, DefaultOnError, OnCompleted>(
+                        std::move(on), DefaultOnError(), std::move(oc));
 }
 template<class T, class DefaultOnError = detail::OnErrorEmpty, class OnNext, class OnError, class OnCompleted>
 auto make_observer(OnNext on, OnError oe, OnCompleted oc)
@@ -351,43 +524,93 @@ auto make_observer(OnNext on, OnError oe, OnCompleted oc)
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>::type {
-    return  observer<T, static_observer<T, OnNext, OnError, OnCompleted>>(
-                        static_observer<T, OnNext, OnError, OnCompleted>(std::move(on), std::move(oe), std::move(oc)));
+            observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>::type {
+    return  observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>(
+                        std::move(on), std::move(oe), std::move(oc));
+}
+
+
+template<class T, class State, class OnNext>
+auto make_observer(State os, OnNext on)
+    -> typename std::enable_if<
+        !detail::is_on_next_of<T, State>::value &&
+        !detail::is_on_error<State>::value,
+            observer<T, State, OnNext>>::type {
+    return  observer<T, State, OnNext>(
+                        std::move(os), std::move(on));
+}
+template<class T, class State, class OnError>
+auto make_observer(State os, OnError oe)
+    -> typename std::enable_if<
+        !detail::is_on_next_of<T, State>::value &&
+        !detail::is_on_error<State>::value &&
+        detail::is_on_error_for<State, OnError>::value,
+            observer<T, State, detail::OnNextEmpty<T>, OnError>>::type {
+    return  observer<T, State, detail::OnNextEmpty<T>, OnError>(
+                        std::move(os), detail::OnNextEmpty<T>(), std::move(oe));
+}
+template<class T, class State, class OnNext, class OnError>
+auto make_observer(State os, OnNext on, OnError oe)
+    -> typename std::enable_if<
+        !detail::is_on_next_of<T, State>::value &&
+        !detail::is_on_error<State>::value &&
+        detail::is_on_error_for<State, OnError>::value,
+            observer<T, State, OnNext, OnError>>::type {
+    return  observer<T, State, OnNext, OnError>(
+                        std::move(os), std::move(on), std::move(oe));
+}
+template<class T, class State, class OnNext, class OnCompleted>
+auto make_observer(State os, OnNext on, OnCompleted oc)
+    -> typename std::enable_if<
+        !detail::is_on_next_of<T, State>::value &&
+        !detail::is_on_error<State>::value,
+            observer<T, State, OnNext, void, OnCompleted>>::type {
+    return  observer<T, State, OnNext, void, OnCompleted>(
+                        std::move(os), std::move(on), std::move(oc));
+}
+template<class T, class State, class OnNext, class OnError, class OnCompleted>
+auto make_observer(State os, OnNext on, OnError oe, OnCompleted oc)
+    -> typename std::enable_if<
+        !detail::is_on_next_of<T, State>::value &&
+        !detail::is_on_error<State>::value &&
+        detail::is_on_error_for<State, OnError>::value,
+            observer<T, State, OnNext, OnError, OnCompleted>>::type {
+    return  observer<T, State, OnNext, OnError, OnCompleted>(
+                        std::move(os), std::move(on), std::move(oe), std::move(oc));
 }
 
 template<class T, class Observer>
 auto make_observer_dynamic(Observer o)
     -> typename std::enable_if<
-        is_observer<Observer>::value,
+        !detail::is_on_next_of<T, Observer>::value,
             observer<T>>::type {
-    return  observer<T>(dynamic_observer<T>(std::move(o)));
+    return  observer<T>(std::move(o));
 }
 template<class T, class OnNext>
 auto make_observer_dynamic(OnNext&& on)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value,
-            observer<T, dynamic_observer<T>>>::type {
-    return  observer<T, dynamic_observer<T>>(
-                        dynamic_observer<T>(make_observer<T>(std::forward<OnNext>(on))));
+            observer<T>>::type {
+    return  observer<T>(
+                make_observer<T>(std::forward<OnNext>(on)));
 }
 template<class T, class OnNext, class OnError>
 auto make_observer_dynamic(OnNext&& on, OnError&& oe)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value,
-            observer<T, dynamic_observer<T>>>::type {
-    return  observer<T, dynamic_observer<T>>(
-                        dynamic_observer<T>(make_observer<T>(std::forward<OnNext>(on), std::forward<OnError>(oe))));
+            observer<T>>::type {
+    return  observer<T>(
+                make_observer<T>(std::forward<OnNext>(on), std::forward<OnError>(oe)));
 }
 template<class T, class OnNext, class OnCompleted>
 auto make_observer_dynamic(OnNext&& on, OnCompleted&& oc)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            observer<T, dynamic_observer<T>>>::type {
-    return  observer<T, dynamic_observer<T>>(
-                        dynamic_observer<T>(make_observer<T>(std::forward<OnNext>(on), std::forward<OnCompleted>(oc))));
+            observer<T>>::type {
+    return  observer<T>(
+                make_observer<T>(std::forward<OnNext>(on), std::forward<OnCompleted>(oc)));
 }
 template<class T, class OnNext, class OnError, class OnCompleted>
 auto make_observer_dynamic(OnNext&& on, OnError&& oe, OnCompleted&& oc)
@@ -395,9 +618,9 @@ auto make_observer_dynamic(OnNext&& on, OnError&& oe, OnCompleted&& oc)
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            observer<T, dynamic_observer<T>>>::type {
-    return  observer<T, dynamic_observer<T>>(
-                        dynamic_observer<T>(make_observer<T>(std::forward<OnNext>(on), std::forward<OnError>(oe), std::forward<OnCompleted>(oc))));
+            observer<T>>::type {
+    return  observer<T>(
+                make_observer<T>(std::forward<OnNext>(on), std::forward<OnError>(oe), std::forward<OnCompleted>(oc)));
 }
 
 namespace detail {

--- a/Rx/v2/src/rxcpp/rx-predef.hpp
+++ b/Rx/v2/src/rxcpp/rx-predef.hpp
@@ -66,12 +66,24 @@ public:
     static const bool value = std::is_convertible<decltype(check<rxu::decay_t<T>>(0)), tag_schedulable*>::value;
 };
 
+namespace detail
+{
 
-template<class T>
-class dynamic_observer;
+struct stateless_observer_tag {};
 
-template<class T, class I = dynamic_observer<T>>
+}
+
+// state with optional overrides
+template<class T, class State = void, class OnNext = void, class OnError = void, class OnCompleted = void>
 class observer;
+
+// no state with optional overrides
+template<class T, class OnNext, class OnError, class OnCompleted>
+class observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>;
+
+// virtual functions forward to dynamically allocated shared observer instance.
+template<class T>
+class observer<T, void, void, void, void>;
 
 struct tag_observer {};
 template<class T>

--- a/Rx/v2/src/rxcpp/rx-subscriber.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscriber.hpp
@@ -234,10 +234,9 @@ template<class T>
 auto make_subscriber()
     -> typename std::enable_if<
         detail::is_on_next_of<T, detail::OnNextEmpty<T>>::value,
-            subscriber<T,   observer<T, static_observer<T, detail::OnNextEmpty<T>>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, detail::OnNextEmpty<T>>>>(trace_id::make_next_id_subscriber(), composite_subscription(),
-                            observer<T, static_observer<T, detail::OnNextEmpty<T>>>(
-                                        static_observer<T, detail::OnNextEmpty<T>>(detail::OnNextEmpty<T>())));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>>(trace_id::make_next_id_subscriber(), composite_subscription(),
+                            observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>(detail::OnNextEmpty<T>()));
 }
 
 template<class T, class I>
@@ -268,30 +267,27 @@ template<class T, class OnNext>
 auto make_subscriber(const OnNext& on)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext>>>(trace_id::make_next_id_subscriber(), composite_subscription(),
-                            observer<T, static_observer<T, OnNext>>(
-                                        static_observer<T, OnNext>(on)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>(trace_id::make_next_id_subscriber(), composite_subscription(),
+                            observer<T, detail::stateless_observer_tag, OnNext>(on));
 }
 template<class T, class OnNext, class OnError>
 auto make_subscriber(const OnNext& on, const OnError& oe)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>(trace_id::make_next_id_subscriber(), composite_subscription(),
-                            observer<T, static_observer<T, OnNext, OnError>>(
-                                        static_observer<T, OnNext, OnError>(on, oe)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>(trace_id::make_next_id_subscriber(), composite_subscription(),
+                            observer<T, detail::stateless_observer_tag, OnNext, OnError>(on, oe));
 }
 template<class T, class OnNext, class OnCompleted>
 auto make_subscriber(const OnNext& on, const OnCompleted& oc)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>(trace_id::make_next_id_subscriber(), composite_subscription(),
-                            observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>(
-                                        static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>(trace_id::make_next_id_subscriber(), composite_subscription(),
+                            observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc));
 }
 template<class T, class OnNext, class OnError, class OnCompleted>
 auto make_subscriber(const OnNext& on, const OnError& oe, const OnCompleted& oc)
@@ -299,10 +295,9 @@ auto make_subscriber(const OnNext& on, const OnError& oe, const OnCompleted& oc)
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>(trace_id::make_next_id_subscriber(), composite_subscription(),
-                            observer<T, static_observer<T, OnNext, OnError, OnCompleted>>(
-                                        static_observer<T, OnNext, OnError, OnCompleted>(on, oe, oc)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>(trace_id::make_next_id_subscriber(), composite_subscription(),
+                            observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>(on, oe, oc));
 }
 
 // explicit lifetime
@@ -310,10 +305,9 @@ auto make_subscriber(const OnNext& on, const OnError& oe, const OnCompleted& oc)
 
 template<class T>
 auto make_subscriber(const composite_subscription& cs)
-    ->      subscriber<T,   observer<T, static_observer<T, detail::OnNextEmpty<T>>>> {
-    return  subscriber<T,   observer<T, static_observer<T, detail::OnNextEmpty<T>>>>(trace_id::make_next_id_subscriber(), cs,
-                            observer<T, static_observer<T, detail::OnNextEmpty<T>>>(
-                                        static_observer<T, detail::OnNextEmpty<T>>(detail::OnNextEmpty<T>())));
+    ->      subscriber<T,   observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>> {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>>(trace_id::make_next_id_subscriber(), cs,
+                            observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>(detail::OnNextEmpty<T>()));
 }
 
 template<class T, class I>
@@ -350,30 +344,27 @@ template<class T, class OnNext>
 auto make_subscriber(const composite_subscription& cs, const OnNext& on)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext>>>(trace_id::make_next_id_subscriber(), cs,
-                            observer<T, static_observer<T, OnNext>>(
-                                        static_observer<T, OnNext>(on)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>(trace_id::make_next_id_subscriber(), cs,
+                            observer<T, detail::stateless_observer_tag, OnNext>(on));
 }
 template<class T, class OnNext, class OnError>
 auto make_subscriber(const composite_subscription& cs, const OnNext& on, const OnError& oe)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>(trace_id::make_next_id_subscriber(), cs,
-                            observer<T, static_observer<T, OnNext, OnError>>(
-                                        static_observer<T, OnNext, OnError>(on, oe)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>(trace_id::make_next_id_subscriber(), cs,
+                            observer<T, detail::stateless_observer_tag, OnNext, OnError>(on, oe));
 }
 template<class T, class OnNext, class OnCompleted>
 auto make_subscriber(const composite_subscription& cs, const OnNext& on, const OnCompleted& oc)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>(trace_id::make_next_id_subscriber(), cs,
-                            observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>(
-                                        static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>(trace_id::make_next_id_subscriber(), cs,
+                            observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc));
 }
 template<class T, class OnNext, class OnError, class OnCompleted>
 auto make_subscriber(const composite_subscription& cs, const OnNext& on, const OnError& oe, const OnCompleted& oc)
@@ -381,10 +372,9 @@ auto make_subscriber(const composite_subscription& cs, const OnNext& on, const O
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>(trace_id::make_next_id_subscriber(), cs,
-                            observer<T, static_observer<T, OnNext, OnError, OnCompleted>>(
-                                        static_observer<T, OnNext, OnError, OnCompleted>(on, oe, oc)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>(trace_id::make_next_id_subscriber(), cs,
+                            observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>(on, oe, oc));
 }
 
 // explicit id
@@ -392,18 +382,16 @@ auto make_subscriber(const composite_subscription& cs, const OnNext& on, const O
 
 template<class T>
 auto make_subscriber(trace_id id)
-    ->      subscriber<T,   observer<T, static_observer<T, detail::OnNextEmpty<T>>>> {
-    return  subscriber<T,   observer<T, static_observer<T, detail::OnNextEmpty<T>>>>(std::move(id), composite_subscription(),
-                            observer<T, static_observer<T, detail::OnNextEmpty<T>>>(
-                                        static_observer<T, detail::OnNextEmpty<T>>(detail::OnNextEmpty<T>())));
+    ->      subscriber<T,   observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>> {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>>(std::move(id), composite_subscription(),
+                            observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>(detail::OnNextEmpty<T>()));
 }
 
 template<class T>
 auto make_subscriber(trace_id id, const composite_subscription& cs)
-    ->      subscriber<T,   observer<T, static_observer<T, detail::OnNextEmpty<T>>>> {
-    return  subscriber<T,   observer<T, static_observer<T, detail::OnNextEmpty<T>>>>(std::move(id), cs,
-                            observer<T, static_observer<T, detail::OnNextEmpty<T>>>(
-                                        static_observer<T, detail::OnNextEmpty<T>>(detail::OnNextEmpty<T>())));
+    ->      subscriber<T,   observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>> {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>>(std::move(id), cs,
+                            observer<T, detail::stateless_observer_tag, detail::OnNextEmpty<T>>(detail::OnNextEmpty<T>()));
 }
 
 template<class T, class I>
@@ -456,59 +444,53 @@ template<class T, class OnNext>
 auto make_subscriber(trace_id id, const OnNext& on)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext>>>(std::move(id), composite_subscription(),
-                            observer<T, static_observer<T, OnNext>>(
-                                        static_observer<T, OnNext>(on)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>(std::move(id), composite_subscription(),
+                            observer<T, detail::stateless_observer_tag, OnNext>(on));
 }
 template<class T, class OnNext>
 auto make_subscriber(trace_id id, const composite_subscription& cs, const OnNext& on)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext>>>(std::move(id), cs,
-                            observer<T, static_observer<T, OnNext>>(
-                                        static_observer<T, OnNext>(on)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>(std::move(id), cs,
+                            observer<T, detail::stateless_observer_tag, OnNext>(on));
 }
 template<class T, class OnNext, class OnError>
 auto make_subscriber(trace_id id, const OnNext& on, const OnError& oe)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>(std::move(id), composite_subscription(),
-                            observer<T, static_observer<T, OnNext, OnError>>(
-                                        static_observer<T, OnNext, OnError>(on, oe)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>(std::move(id), composite_subscription(),
+                            observer<T, detail::stateless_observer_tag, OnNext, OnError>(on, oe));
 }
 template<class T, class OnNext, class OnError>
 auto make_subscriber(trace_id id, const composite_subscription& cs, const OnNext& on, const OnError& oe)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>(std::move(id), cs,
-                            observer<T, static_observer<T, OnNext, OnError>>(
-                                        static_observer<T, OnNext, OnError>(on, oe)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>(std::move(id), cs,
+                            observer<T, detail::stateless_observer_tag, OnNext, OnError>(on, oe));
 }
 template<class T, class OnNext, class OnCompleted>
 auto make_subscriber(trace_id id, const OnNext& on, const OnCompleted& oc)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>(std::move(id), composite_subscription(),
-                            observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>(
-                                        static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>(std::move(id), composite_subscription(),
+                            observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc));
 }
 template<class T, class OnNext, class OnCompleted>
 auto make_subscriber(trace_id id, const composite_subscription& cs, const OnNext& on, const OnCompleted& oc)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>(std::move(id), cs,
-                            observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>(
-                                        static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>(std::move(id), cs,
+                            observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc));
 }
 template<class T, class OnNext, class OnError, class OnCompleted>
 auto make_subscriber(trace_id id, const OnNext& on, const OnError& oe, const OnCompleted& oc)
@@ -516,10 +498,9 @@ auto make_subscriber(trace_id id, const OnNext& on, const OnError& oe, const OnC
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>(std::move(id), composite_subscription(),
-                            observer<T, static_observer<T, OnNext, OnError, OnCompleted>>(
-                                        static_observer<T, OnNext, OnError, OnCompleted>(on, oe, oc)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>(std::move(id), composite_subscription(),
+                            observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>(on, oe, oc));
 }
 template<class T, class OnNext, class OnError, class OnCompleted>
 auto make_subscriber(trace_id id, const composite_subscription& cs, const OnNext& on, const OnError& oe, const OnCompleted& oc)
@@ -527,10 +508,9 @@ auto make_subscriber(trace_id id, const composite_subscription& cs, const OnNext
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value &&
         detail::is_on_completed<OnCompleted>::value,
-            subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>>::type {
-    return  subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>(std::move(id), cs,
-                            observer<T, static_observer<T, OnNext, OnError, OnCompleted>>(
-                                        static_observer<T, OnNext, OnError, OnCompleted>(on, oe, oc)));
+            subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>>::type {
+    return  subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>(std::move(id), cs,
+                            observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>(on, oe, oc));
 }
 
 // chain defaults from subscriber
@@ -599,10 +579,9 @@ template<class T, class OtherT, class OtherObserver, class OnNext>
 auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, const OnNext& on)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext>>>(trace_id::make_next_id_subscriber(), scbr.get_subscription(),
-                            observer<T, static_observer<T, OnNext>>(
-                                        static_observer<T, OnNext>(on)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>(trace_id::make_next_id_subscriber(), scbr.get_subscription(),
+                             observer<T, detail::stateless_observer_tag, OnNext>(on));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -610,10 +589,9 @@ template<class T, class OtherT, class OtherObserver, class OnNext>
 auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, trace_id id, const OnNext& on)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext>>>(std::move(id), scbr.get_subscription(),
-                            observer<T, static_observer<T, OnNext>>(
-                                        static_observer<T, OnNext>(on)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>(std::move(id), scbr.get_subscription(),
+                             observer<T, detail::stateless_observer_tag, OnNext>(on));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -622,10 +600,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, const OnNext
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>(trace_id::make_next_id_subscriber(), scbr.get_subscription(),
-                            observer<T, static_observer<T, OnNext, OnError>>(
-                                        static_observer<T, OnNext, OnError>(on, oe)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>(trace_id::make_next_id_subscriber(), scbr.get_subscription(),
+                             observer<T, detail::stateless_observer_tag, OnNext, OnError>(on, oe));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -634,10 +611,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, trace_id id,
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>(std::move(id), scbr.get_subscription(),
-                            observer<T, static_observer<T, OnNext, OnError>>(
-                                        static_observer<T, OnNext, OnError>(on, oe)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>(std::move(id), scbr.get_subscription(),
+                             observer<T, detail::stateless_observer_tag, OnNext, OnError>(on, oe));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -646,10 +622,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, const OnNext
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_completed<OnCompleted>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>(trace_id::make_next_id_subscriber(), scbr.get_subscription(),
-                            observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>(
-                                        static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>(trace_id::make_next_id_subscriber(), scbr.get_subscription(),
+                             observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -658,10 +633,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, trace_id id,
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_completed<OnCompleted>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>(std::move(id), scbr.get_subscription(),
-                            observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>(
-                                        static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>(std::move(id), scbr.get_subscription(),
+                             observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -671,10 +645,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, const OnNext
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value &&
         detail::is_on_completed<OnCompleted>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>(trace_id::make_next_id_subscriber(), scbr.get_subscription(),
-                            observer<T, static_observer<T, OnNext, OnError, OnCompleted>>(
-                                        static_observer<T, OnNext, OnError, OnCompleted>(on, oe, oc)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>(trace_id::make_next_id_subscriber(), scbr.get_subscription(),
+                             observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>(on, oe, oc));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -684,10 +657,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, trace_id id,
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value &&
         detail::is_on_completed<OnCompleted>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>(std::move(id), scbr.get_subscription(),
-                            observer<T, static_observer<T, OnNext, OnError, OnCompleted>>(
-                                        static_observer<T, OnNext, OnError, OnCompleted>(on, oe, oc)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>(std::move(id), scbr.get_subscription(),
+                             observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>(on, oe, oc));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -750,10 +722,9 @@ template<class T, class OtherT, class OtherObserver, class OnNext>
 auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, const composite_subscription& cs, const OnNext& on)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext>>>(trace_id::make_next_id_subscriber(), cs,
-                            observer<T, static_observer<T, OnNext>>(
-                                        static_observer<T, OnNext>(on)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>(trace_id::make_next_id_subscriber(), cs,
+                             observer<T, detail::stateless_observer_tag, OnNext>(on));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -761,10 +732,9 @@ template<class T, class OtherT, class OtherObserver, class OnNext>
 auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, trace_id id, const composite_subscription& cs, const OnNext& on)
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext>>>(std::move(id), cs,
-                            observer<T, static_observer<T, OnNext>>(
-                                        static_observer<T, OnNext>(on)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext>>(std::move(id), cs,
+                             observer<T, detail::stateless_observer_tag, OnNext>(on));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -773,10 +743,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, const compos
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>(trace_id::make_next_id_subscriber(), cs,
-                            observer<T, static_observer<T, OnNext, OnError>>(
-                                        static_observer<T, OnNext, OnError>(on, oe)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>(trace_id::make_next_id_subscriber(), cs,
+                             observer<T, detail::stateless_observer_tag, OnNext, OnError>(on, oe));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -785,10 +754,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, trace_id id,
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, OnError>>>(std::move(id), cs,
-                            observer<T, static_observer<T, OnNext, OnError>>(
-                                        static_observer<T, OnNext, OnError>(on, oe)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError>>(std::move(id), cs,
+                             observer<T, detail::stateless_observer_tag, OnNext, OnError>(on, oe));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -797,10 +765,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, const compos
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_completed<OnCompleted>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>(trace_id::make_next_id_subscriber(), cs,
-                            observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>(
-                                        static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>(trace_id::make_next_id_subscriber(), cs,
+                             observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -809,10 +776,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, trace_id id,
     -> typename std::enable_if<
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_completed<OnCompleted>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>>(std::move(id), cs,
-                            observer<T, static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>>(
-                                        static_observer<T, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>>(std::move(id), cs,
+                             observer<T, detail::stateless_observer_tag, OnNext, detail::OnErrorEmpty, OnCompleted>(on, detail::OnErrorEmpty(), oc));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -822,10 +788,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, const compos
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value &&
         detail::is_on_completed<OnCompleted>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>(trace_id::make_next_id_subscriber(), cs,
-                            observer<T, static_observer<T, OnNext, OnError, OnCompleted>>(
-                                        static_observer<T, OnNext, OnError, OnCompleted>(on, oe, oc)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>(trace_id::make_next_id_subscriber(), cs,
+                             observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>(on, oe, oc));
     trace_activity().connect(r, scbr);
     return r;
 }
@@ -835,10 +800,9 @@ auto make_subscriber(const subscriber<OtherT, OtherObserver>& scbr, trace_id id,
         detail::is_on_next_of<T, OnNext>::value &&
         detail::is_on_error<OnError>::value &&
         detail::is_on_completed<OnCompleted>::value,
-             subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>>::type {
-    auto r = subscriber<T,   observer<T, static_observer<T, OnNext, OnError, OnCompleted>>>(std::move(id), cs,
-                            observer<T, static_observer<T, OnNext, OnError, OnCompleted>>(
-                                        static_observer<T, OnNext, OnError, OnCompleted>(on, oe, oc)));
+             subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>>::type {
+    auto r = subscriber<T,   observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>>(std::move(id), cs,
+                             observer<T, detail::stateless_observer_tag, OnNext, OnError, OnCompleted>(on, oe, oc));
     trace_activity().connect(r, scbr);
     return r;
 }

--- a/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
@@ -15,9 +15,7 @@ namespace detail {
 
 template<class T>
 class multicast_observer
-    : public observer_base<T>
 {
-    typedef observer_base<T> base;
     typedef subscriber<T> observer_type;
     typedef std::vector<observer_type> list_type;
 

--- a/Rx/v2/test/sources/create.cpp
+++ b/Rx/v2/test/sources/create.cpp
@@ -44,3 +44,47 @@ SCENARIO("create stops on completion", "[create][sources]"){
         }
     }
 }
+
+SCENARIO("when observer::on_next is overridden", "[create][observer][sources]"){
+    GIVEN("a test cold observable of ints"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        long invoked = 0;
+
+        WHEN("created"){
+
+            auto res = w.start(
+                [&]() {
+                    return rx::observable<>::create<int>(
+                        [&](const rx::subscriber<int>& so){
+                            invoked++;
+                            auto sn = rx::make_subscriber<int>(so,
+                                rx::make_observer<int>(so.get_observer(),
+                                    [](rx::observer<int>& o, int v){
+                                        o.on_next(v + 1);
+                                    }));
+                            sn.on_next(1);
+                            sn.on_next(2);
+                        })
+                        // forget type to workaround lambda deduction bug on msvc 2013
+                        .as_dynamic();
+                }
+            );
+
+            THEN("the output contains all items incremented by 1"){
+                auto required = rxu::to_vector({
+                    on.next(200, 2),
+                    on.next(200, 3)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("create was called until completed"){
+                REQUIRE(1 == invoked);
+            }
+        }
+    }
+}


### PR DESCRIPTION
removed dynamic_ and static_ 
Now using template specializations of observer instead.

I also added an observer specialization that stores a state and optionally takes 

Template Parameter | Function Type
-----|-----
OnNext | `void(State&, T)`
OnError | `void(State&, std::exception_ptr)`
OnCompleted | `void(State&)`

if a function is supplied it is called, if a function is not supplied then `State::on_next(T)`, `State::on_error(std::exception_ptr)`, `State::on_completed()` are called.

```cpp
rx::observable<>::create<int>(
    [&](const rx::subscriber<int>& so){
        // override the observer in the subscriber
        auto sn = rx::make_subscriber<int>(so,
            // override only on_next on the observer
            rx::make_observer<int>(so.get_observer(),
                [](rx::observer<int>& o, int v){
                    o.on_next(v + 1);
                }));
        sn.on_next(1);
        sn.on_next(2);
    });
```

due to the override this would output `[2, 3]` instead of `[1, 2]`

State does not have to be an Observer, but then all three functions must be supplied.
