### PR TITLE
improve support for android

### DIFF
--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -93,6 +93,10 @@
 #endif
 #endif
 
+#if defined(__ANDROID__)
+#define RXCPP_ON_ANDROID
+#endif
+
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -127,7 +131,7 @@
 #include <typeinfo>
 #include <tuple>
 
-#if defined(RXCPP_ON_IOS)
+#if defined(RXCPP_ON_IOS) || defined(RXCPP_ON_ANDROID)
 #include <pthread.h>
 #endif
 

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -7,7 +7,7 @@
 
 #include "rx-includes.hpp"
 
-#if !defined(RXCPP_ON_IOS) && !defined(RXCPP_THREAD_LOCAL)
+#if !defined(RXCPP_ON_IOS) && !defined(RXCPP_ON_ANDROID) && !defined(RXCPP_THREAD_LOCAL)
 #if defined(_MSC_VER)
 #define RXCPP_THREAD_LOCAL __declspec(thread)
 #else


### PR DESCRIPTION
fixes #184 

Now you don't have to define RXCPP_ON_IOS in order to use the library on Android.
