### PR TITLE
add async-subject

### DIFF
--- a/Rx/v2/src/rxcpp/rx-subjects.hpp
+++ b/Rx/v2/src/rxcpp/rx-subjects.hpp
@@ -17,6 +17,7 @@ namespace rxsub=subjects;
 }
 
 #include "subjects/rx-subject.hpp"
+#include "subjects/rx-async-subject.hpp"
 #include "subjects/rx-behavior.hpp"
 #include "subjects/rx-replaysubject.hpp"
 #include "subjects/rx-synchronize.hpp"

--- a/Rx/v2/src/rxcpp/subjects/rx-async-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-async-subject.hpp
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+#pragma once
+
+#if !defined(RXCPP_RX_ASYNC_SUBJECT_HPP)
+#define RXCPP_RX_ASYNC_SUBJECT_HPP
+
+#include "../rx-includes.hpp"
+
+namespace rxcpp {
+
+namespace subjects {
+
+namespace detail {
+
+struct multicast_async_state_type
+    : public std::enable_shared_from_this<multicast_async_state_type>
+{
+    struct mode
+    {
+        enum type {
+            Invalid = 0,
+            Casting,
+            Disposed,
+            Completed,
+            Errored
+        };
+    };
+
+    explicit multicast_async_state_type(composite_subscription cs)
+        : generation(0)
+        , current(mode::Casting)
+        , lifetime(cs)
+    {
+    }
+    std::atomic<int> generation;
+    std::mutex lock;
+    typename mode::type current;
+    std::exception_ptr error;
+    composite_subscription lifetime;
+
+    template<class F,class observer_type>
+    void map( std::vector<observer_type> &l, F f ) {
+        std::unique_lock<std::mutex> guard(lock);
+        for (auto& o : l) f(o);
+    }
+
+};
+
+}
+
+
+template<class T>
+class async_subject
+{
+    detail::multicast_observer<T,detail::multicast_async_state_type> s;
+
+public:
+    typedef subscriber<T, observer<T, detail::multicast_observer<T,detail::multicast_async_state_type>>> subscriber_type;
+    typedef observable<T> observable_type;
+    async_subject()
+        : s(composite_subscription())
+    {
+    }
+    explicit async_subject(composite_subscription cs)
+        : s(cs)
+    {
+    }
+
+    bool has_observers() const {
+        return s.has_observers();
+    }
+
+    subscriber_type get_subscriber() const {
+        return s.get_subscriber();
+    }
+
+    observable<T> get_observable() const {
+        auto keepAlive = s;
+        return make_observable_dynamic<T>([=](subscriber<T> o){
+            keepAlive.add(keepAlive.get_subscriber(), std::move(o));
+        });
+    }
+};
+
+}
+
+}
+
+#endif

--- a/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
@@ -13,12 +13,9 @@ namespace subjects {
 
 namespace detail {
 
-template<class T>
-class multicast_observer
+struct multicast_sync_state_type
+    : public std::enable_shared_from_this<multicast_sync_state_type>
 {
-    typedef subscriber<T> observer_type;
-    typedef std::vector<observer_type> list_type;
-
     struct mode
     {
         enum type {
@@ -30,21 +27,30 @@ class multicast_observer
         };
     };
 
-    struct state_type
-        : public std::enable_shared_from_this<state_type>
+    explicit multicast_sync_state_type(composite_subscription cs)
+        : generation(0)
+        , current(mode::Casting)
+        , lifetime(cs)
     {
-        explicit state_type(composite_subscription cs)
-            : generation(0)
-            , current(mode::Casting)
-            , lifetime(cs)
-        {
-        }
-        std::atomic<int> generation;
-        std::mutex lock;
-        typename mode::type current;
-        std::exception_ptr error;
-        composite_subscription lifetime;
-    };
+    }
+    std::atomic<int> generation;
+    std::mutex lock;
+    typename mode::type current;
+    std::exception_ptr error;
+    composite_subscription lifetime;
+
+    template<class F,class observer_type>
+    void map( std::vector<observer_type> &l, F f ) { for (auto& o : l) f(o); }
+
+};
+
+
+template<class T,class state_type=multicast_sync_state_type>
+class multicast_observer
+{
+    typedef subscriber<T> observer_type;
+    typedef std::vector<observer_type> list_type;
+    typedef typename state_type::mode mode;
 
     struct completer_type
         : public std::enable_shared_from_this<completer_type>
@@ -96,7 +102,7 @@ class multicast_observer
     std::shared_ptr<binder_type> b;
 
 public:
-    typedef subscriber<T, observer<T, detail::multicast_observer<T>>> input_subscriber_type;
+    typedef subscriber<T, observer<T, detail::multicast_observer<T,state_type>>> input_subscriber_type;
 
     explicit multicast_observer(composite_subscription cs)
         : b(std::make_shared<binder_type>(cs))
@@ -118,7 +124,7 @@ public:
         return b->state->lifetime;
     }
     input_subscriber_type get_subscriber() const {
-        return make_subscriber<T>(get_id(), get_subscription(), observer<T, detail::multicast_observer<T>>(*this));
+        return make_subscriber<T>(get_id(), get_subscription(), observer<T, detail::multicast_observer<T,state_type>>(*this));
     }
     bool has_observers() const {
         std::unique_lock<std::mutex> guard(b->state->lock);
@@ -175,11 +181,7 @@ public:
         if (!current_completer || current_completer->observers.empty()) {
             return;
         }
-        for (auto& o : current_completer->observers) {
-            if (o.is_subscribed()) {
-                o.on_next(v);
-            }
-        }
+        current_completer->state->map( current_completer->observers, [&](observer_type &o) { if (o.is_subscribed( )) o.on_next(v); } );
     }
     void on_error(std::exception_ptr e) const {
         std::unique_lock<std::mutex> guard(b->state->lock);
@@ -192,11 +194,7 @@ public:
             ++b->state->generation;
             guard.unlock();
             if (c) {
-                for (auto& o : c->observers) {
-                    if (o.is_subscribed()) {
-                        o.on_error(e);
-                    }
-                }
+                c->state->map( c->observers, [&](observer_type &o) { if (o.is_subscribed( )) o.on_error(e); } );
             }
             s.unsubscribe();
         }
@@ -211,11 +209,7 @@ public:
             ++b->state->generation;
             guard.unlock();
             if (c) {
-                for (auto& o : c->observers) {
-                    if (o.is_subscribed()) {
-                        o.on_completed();
-                    }
-                }
+                c->state->map( c->observers, [&](observer_type &o) { if (o.is_subscribed( )) o.on_completed( ); } );
             }
             s.unsubscribe();
         }


### PR DESCRIPTION
I intended to open an issue instead of a pull request, but I could not find a way to include diffs in an issue request. This pull request includes my changes to add async_subject to RxCpp. I used it to create to_async(f) as shown below. Please let me know if you have any suggested changes or improvements or (of course) bugs!

    namespace details {
        template<class F, class R, class... A>
        struct to_async_functor {
            F f;
            to_async_functor( F f_ ) : f(move(f_)) { }
            rxcpp::subjects::async_subject<R> result(A... a);
            rxcpp::observable<R> operator( )(const A&... a) {
                auto result = rxcpp::subjects::async_subject<R>( );
                rxcpp::observe_on_new_thread().create_coordinator().get_worker().schedule(
                    [=](const rxcpp::rxsc::schedulable&) {
                        rxcpp::util::maybe<R> value;
                        try {
                            value = f(a...);
                            result.get_subscriber( ).on_next(value.get( ));
                            result.get_subscriber( ).on_completed( );
                        } catch (...) {
                            result.get_subscriber( ).on_error(std::current_exception());
                        }
                    } );
                return result.get_observable( );
            }
        };
    }
    
    template<class... A, class F>
    auto to_async( F f )
        -> details::to_async_functor<F,decltype(f((*(A*) nullptr)...)),A...>
    {
        typedef decltype(f((*(A*) nullptr)...)) R;
        return details::to_async_functor<F,R,A...>(f);
    }
