### PR TITLE
Reduce use of new

### DIFF
--- a/Rx/v2/test/operators/group_by.cpp
+++ b/Rx/v2/test/operators/group_by.cpp
@@ -200,7 +200,7 @@ SCENARIO("group_by", "[group_by][operators]"){
             on.completed(570),
             on.next(580, "error"),
             on.completed(600),
-            on.error(650, new std::runtime_error("error in completed sequence"))
+            on.error(650, std::runtime_error("error in completed sequence"))
         });
 
         WHEN("group each int with the next 2 ints"){

--- a/Rx/v2/test/subscriptions/subscription.cpp
+++ b/Rx/v2/test/subscriptions/subscription.cpp
@@ -3,7 +3,7 @@
 SCENARIO("observe subscription", "[hide]"){
     GIVEN("observable of ints"){
         WHEN("subscribe"){
-            std::shared_ptr<std::list<rxcpp::subscriber<int>>> observers(new std::list<rxcpp::subscriber<int>>());
+            auto observers = std::make_shared<std::list<rxcpp::subscriber<int>>>();
 
             auto observable = rxcpp::observable<>::create<int>([=](rxcpp::subscriber<int> out){
                 auto it = observers->insert(observers->end(), out);


### PR DESCRIPTION
Fixes a leak in a test and use make_shared instead of shared_ptr(new ...