### PR TITLE
add hash implementations for time_point and duration

### DIFF
--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -749,6 +749,26 @@ struct filtered_hash<T, typename std::enable_if<std::is_pointer<T>::value>::type
 template <class T> 
 struct filtered_hash<T, typename std::enable_if<rxu::is_string<T>::value>::type> : std::hash<T> {
 };
+template <class T>
+struct filtered_hash<T, typename std::enable_if<std::is_convertible<T, std::chrono::duration<typename T::rep, typename T::period>>::value>::type> {
+    using argument_type = T;
+    using result_type = std::size_t;
+
+    result_type operator()(argument_type const & dur) const
+    {
+        return std::hash<typename argument_type::rep>{}(dur.count());
+    }
+};
+template <class T>
+struct filtered_hash<T, typename std::enable_if<std::is_convertible<T, std::chrono::time_point<typename T::clock, typename T::duration>>::value>::type> {
+    using argument_type = T;
+    using result_type = std::size_t;
+
+    result_type operator()(argument_type const & tp) const
+    {
+        return std::hash<typename argument_type::rep>{}(tp.time_since_epoch().count());
+    }
+};
 
 template<typename, typename C = rxu::types_checked>
 struct is_hashable

--- a/Rx/v2/test/operators/distinct.cpp
+++ b/Rx/v2/test/operators/distinct.cpp
@@ -340,6 +340,282 @@ SCENARIO("distinct - strings", "[distinct][operators]"){
     }
 }
 
+SCENARIO("distinct - system_clock's duration", "[distinct][operators]") {
+    GIVEN("a source") {
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        using namespace std::chrono;
+        const rxsc::test::messages<system_clock::duration> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 10s),
+            on.next(210, 20s),
+            on.next(220, 20s),
+            on.next(230, 100s),
+            on.next(240, 100s),
+            on.completed(250)
+        });
+
+        WHEN("distinct values are taken") {
+
+            auto res = w.start(
+                [xs]() {
+                return xs.distinct();
+            }
+            );
+
+            THEN("the output only contains distinct items sent while subscribed") {
+                auto required = rxu::to_vector({
+                    on.next(210, 20s),
+                    on.next(230, 100s),
+                    on.completed(250)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source") {
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
+SCENARIO("distinct - high_resolution_clock's duration", "[distinct][operators]") {
+    GIVEN("a source") {
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        using namespace std::chrono;
+        const rxsc::test::messages<high_resolution_clock::duration> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 10s),
+            on.next(210, 20s),
+            on.next(220, 20s),
+            on.next(230, 100s),
+            on.next(240, 100s),
+            on.completed(250)
+        });
+
+        WHEN("distinct values are taken") {
+
+            auto res = w.start(
+                [xs]() {
+                return xs.distinct();
+            }
+            );
+
+            THEN("the output only contains distinct items sent while subscribed") {
+                auto required = rxu::to_vector({
+                    on.next(210, 20s),
+                    on.next(230, 100s),
+                    on.completed(250)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source") {
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
+SCENARIO("distinct - steady_clock's duration", "[distinct][operators]") {
+    GIVEN("a source") {
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        using namespace std::chrono;
+        const rxsc::test::messages<steady_clock::duration> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 10s),
+            on.next(210, 20s),
+            on.next(220, 20s),
+            on.next(230, 100s),
+            on.next(240, 100s),
+            on.completed(250)
+        });
+
+        WHEN("distinct values are taken") {
+
+            auto res = w.start(
+                [xs]() {
+                return xs.distinct();
+            }
+            );
+
+            THEN("the output only contains distinct items sent while subscribed") {
+                auto required = rxu::to_vector({
+                    on.next(210, 20s),
+                    on.next(230, 100s),
+                    on.completed(250)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source") {
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
+SCENARIO("distinct - system_clock's time_point", "[distinct][operators]") {
+    GIVEN("a source") {
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        using namespace std::chrono;
+        const rxsc::test::messages<system_clock::time_point> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, system_clock::time_point{ 10s }),
+            on.next(210, system_clock::time_point{ 20s }),
+            on.next(220, system_clock::time_point{ 20s }),
+            on.next(230, system_clock::time_point{ 100s }),
+            on.next(240, system_clock::time_point{ 100s }),
+            on.completed(250)
+        });
+
+        WHEN("distinct values are taken") {
+
+            auto res = w.start(
+                [xs]() {
+                return xs.distinct();
+            }
+            );
+
+            THEN("the output only contains distinct items sent while subscribed") {
+                auto required = rxu::to_vector({
+                    on.next(210, system_clock::time_point{ 20s }),
+                    on.next(230, system_clock::time_point{ 100s }),
+                    on.completed(250)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source") {
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
+SCENARIO("distinct - high_resolution_clock's time_point", "[distinct][operators]") {
+    GIVEN("a source") {
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        using namespace std::chrono;
+        const rxsc::test::messages<high_resolution_clock::time_point> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, high_resolution_clock::time_point{ 10s }),
+            on.next(210, high_resolution_clock::time_point{ 20s }),
+            on.next(220, high_resolution_clock::time_point{ 20s }),
+            on.next(230, high_resolution_clock::time_point{ 100s }),
+            on.next(240, high_resolution_clock::time_point{ 100s }),
+            on.completed(250)
+        });
+
+        WHEN("distinct values are taken") {
+
+            auto res = w.start(
+                [xs]() {
+                return xs.distinct();
+            }
+            );
+
+            THEN("the output only contains distinct items sent while subscribed") {
+                auto required = rxu::to_vector({
+                    on.next(210, high_resolution_clock::time_point{ 20s }),
+                    on.next(230, high_resolution_clock::time_point{ 100s }),
+                    on.completed(250)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source") {
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
+SCENARIO("distinct - steady_clock's time_point", "[distinct][operators]") {
+    GIVEN("a source") {
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        using namespace std::chrono;
+        const rxsc::test::messages<steady_clock::time_point> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, steady_clock::time_point{ 10s }),
+            on.next(210, steady_clock::time_point{ 20s }),
+            on.next(220, steady_clock::time_point{ 20s }),
+            on.next(230, steady_clock::time_point{ 100s }),
+            on.next(240, steady_clock::time_point{ 100s }),
+            on.completed(250)
+        });
+
+        WHEN("distinct values are taken") {
+
+            auto res = w.start(
+                [xs]() {
+                return xs.distinct();
+            }
+            );
+
+            THEN("the output only contains distinct items sent while subscribed") {
+                auto required = rxu::to_vector({
+                    on.next(210, steady_clock::time_point{ 20s }),
+                    on.next(230, steady_clock::time_point{ 100s }),
+                    on.completed(250)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source") {
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
 SCENARIO("distinct - enum", "[distinct][operators]"){
     enum Value {
         A,

--- a/Rx/v2/test/operators/distinct.cpp
+++ b/Rx/v2/test/operators/distinct.cpp
@@ -348,11 +348,11 @@ SCENARIO("distinct - system_clock's duration", "[distinct][operators]") {
         const rxsc::test::messages<system_clock::duration> on;
 
         auto xs = sc.make_hot_observable({
-            on.next(150, 10s),
-            on.next(210, 20s),
-            on.next(220, 20s),
-            on.next(230, 100s),
-            on.next(240, 100s),
+            on.next(150, system_clock::duration{ 10 }),
+            on.next(210, system_clock::duration{ 20 }),
+            on.next(220, system_clock::duration{ 20 }),
+            on.next(230, system_clock::duration{ 100 }),
+            on.next(240, system_clock::duration{ 100 }),
             on.completed(250)
         });
 
@@ -366,8 +366,8 @@ SCENARIO("distinct - system_clock's duration", "[distinct][operators]") {
 
             THEN("the output only contains distinct items sent while subscribed") {
                 auto required = rxu::to_vector({
-                    on.next(210, 20s),
-                    on.next(230, 100s),
+                    on.next(210, system_clock::duration{ 20 }),
+                    on.next(230, system_clock::duration{ 100 }),
                     on.completed(250)
                 });
                 auto actual = res.get_observer().messages();
@@ -394,11 +394,11 @@ SCENARIO("distinct - high_resolution_clock's duration", "[distinct][operators]")
         const rxsc::test::messages<high_resolution_clock::duration> on;
 
         auto xs = sc.make_hot_observable({
-            on.next(150, 10s),
-            on.next(210, 20s),
-            on.next(220, 20s),
-            on.next(230, 100s),
-            on.next(240, 100s),
+            on.next(150, high_resolution_clock::duration{ 10 }),
+            on.next(210, high_resolution_clock::duration{ 20 }),
+            on.next(220, high_resolution_clock::duration{ 20 }),
+            on.next(230, high_resolution_clock::duration{ 100 }),
+            on.next(240, high_resolution_clock::duration{ 100 }),
             on.completed(250)
         });
 
@@ -412,8 +412,8 @@ SCENARIO("distinct - high_resolution_clock's duration", "[distinct][operators]")
 
             THEN("the output only contains distinct items sent while subscribed") {
                 auto required = rxu::to_vector({
-                    on.next(210, 20s),
-                    on.next(230, 100s),
+                    on.next(210, high_resolution_clock::duration{ 20 }),
+                    on.next(230, high_resolution_clock::duration{ 100 }),
                     on.completed(250)
                 });
                 auto actual = res.get_observer().messages();
@@ -440,11 +440,11 @@ SCENARIO("distinct - steady_clock's duration", "[distinct][operators]") {
         const rxsc::test::messages<steady_clock::duration> on;
 
         auto xs = sc.make_hot_observable({
-            on.next(150, 10s),
-            on.next(210, 20s),
-            on.next(220, 20s),
-            on.next(230, 100s),
-            on.next(240, 100s),
+            on.next(150, steady_clock::duration{ 10 }),
+            on.next(210, steady_clock::duration{ 20 }),
+            on.next(220, steady_clock::duration{ 20 }),
+            on.next(230, steady_clock::duration{ 100 }),
+            on.next(240, steady_clock::duration{ 100 }),
             on.completed(250)
         });
 
@@ -458,8 +458,8 @@ SCENARIO("distinct - steady_clock's duration", "[distinct][operators]") {
 
             THEN("the output only contains distinct items sent while subscribed") {
                 auto required = rxu::to_vector({
-                    on.next(210, 20s),
-                    on.next(230, 100s),
+                    on.next(210, steady_clock::duration{ 20 }),
+                    on.next(230, steady_clock::duration{ 100 }),
                     on.completed(250)
                 });
                 auto actual = res.get_observer().messages();
@@ -486,11 +486,11 @@ SCENARIO("distinct - system_clock's time_point", "[distinct][operators]") {
         const rxsc::test::messages<system_clock::time_point> on;
 
         auto xs = sc.make_hot_observable({
-            on.next(150, system_clock::time_point{ 10s }),
-            on.next(210, system_clock::time_point{ 20s }),
-            on.next(220, system_clock::time_point{ 20s }),
-            on.next(230, system_clock::time_point{ 100s }),
-            on.next(240, system_clock::time_point{ 100s }),
+            on.next(150, system_clock::time_point{ system_clock::duration{ 10 } }),
+            on.next(210, system_clock::time_point{ system_clock::duration{ 20 } }),
+            on.next(220, system_clock::time_point{ system_clock::duration{ 20 } }),
+            on.next(230, system_clock::time_point{ system_clock::duration{ 100 } }),
+            on.next(240, system_clock::time_point{ system_clock::duration{ 100 } }),
             on.completed(250)
         });
 
@@ -504,8 +504,8 @@ SCENARIO("distinct - system_clock's time_point", "[distinct][operators]") {
 
             THEN("the output only contains distinct items sent while subscribed") {
                 auto required = rxu::to_vector({
-                    on.next(210, system_clock::time_point{ 20s }),
-                    on.next(230, system_clock::time_point{ 100s }),
+                    on.next(210, system_clock::time_point{ system_clock::duration{ 20 } }),
+                    on.next(230, system_clock::time_point{ system_clock::duration{ 100 } }),
                     on.completed(250)
                 });
                 auto actual = res.get_observer().messages();
@@ -532,11 +532,11 @@ SCENARIO("distinct - high_resolution_clock's time_point", "[distinct][operators]
         const rxsc::test::messages<high_resolution_clock::time_point> on;
 
         auto xs = sc.make_hot_observable({
-            on.next(150, high_resolution_clock::time_point{ 10s }),
-            on.next(210, high_resolution_clock::time_point{ 20s }),
-            on.next(220, high_resolution_clock::time_point{ 20s }),
-            on.next(230, high_resolution_clock::time_point{ 100s }),
-            on.next(240, high_resolution_clock::time_point{ 100s }),
+            on.next(150, high_resolution_clock::time_point{ high_resolution_clock::duration{ 10 } }),
+            on.next(210, high_resolution_clock::time_point{ high_resolution_clock::duration{ 20 } }),
+            on.next(220, high_resolution_clock::time_point{ high_resolution_clock::duration{ 20 } }),
+            on.next(230, high_resolution_clock::time_point{ high_resolution_clock::duration{ 100 } }),
+            on.next(240, high_resolution_clock::time_point{ high_resolution_clock::duration{ 100 } }),
             on.completed(250)
         });
 
@@ -550,8 +550,8 @@ SCENARIO("distinct - high_resolution_clock's time_point", "[distinct][operators]
 
             THEN("the output only contains distinct items sent while subscribed") {
                 auto required = rxu::to_vector({
-                    on.next(210, high_resolution_clock::time_point{ 20s }),
-                    on.next(230, high_resolution_clock::time_point{ 100s }),
+                    on.next(210, high_resolution_clock::time_point{ high_resolution_clock::duration{ 20 } }),
+                    on.next(230, high_resolution_clock::time_point{ high_resolution_clock::duration{ 100 } }),
                     on.completed(250)
                 });
                 auto actual = res.get_observer().messages();
@@ -578,11 +578,11 @@ SCENARIO("distinct - steady_clock's time_point", "[distinct][operators]") {
         const rxsc::test::messages<steady_clock::time_point> on;
 
         auto xs = sc.make_hot_observable({
-            on.next(150, steady_clock::time_point{ 10s }),
-            on.next(210, steady_clock::time_point{ 20s }),
-            on.next(220, steady_clock::time_point{ 20s }),
-            on.next(230, steady_clock::time_point{ 100s }),
-            on.next(240, steady_clock::time_point{ 100s }),
+            on.next(150, steady_clock::time_point{ steady_clock::duration{ 10 } }),
+            on.next(210, steady_clock::time_point{ steady_clock::duration{ 20 } }),
+            on.next(220, steady_clock::time_point{ steady_clock::duration{ 20 } }),
+            on.next(230, steady_clock::time_point{ steady_clock::duration{ 100 } }),
+            on.next(240, steady_clock::time_point{ steady_clock::duration{ 100 } }),
             on.completed(250)
         });
 
@@ -596,8 +596,8 @@ SCENARIO("distinct - steady_clock's time_point", "[distinct][operators]") {
 
             THEN("the output only contains distinct items sent while subscribed") {
                 auto required = rxu::to_vector({
-                    on.next(210, steady_clock::time_point{ 20s }),
-                    on.next(230, steady_clock::time_point{ 100s }),
+                    on.next(210, steady_clock::time_point{ steady_clock::duration{ 20 } }),
+                    on.next(230, steady_clock::time_point{ steady_clock::duration{ 100 } }),
                     on.completed(250)
                 });
                 auto actual = res.get_observer().messages();


### PR DESCRIPTION
So here goes my try at it!

I wanted to make a is_primitive_type trait similar to is_string, but since both duration and time_point expose rep and period it resulted in partial template specialization ambiguous resolution. So I ended up with is_convertible.