### PR TITLE
remove cast to std::function inside contains operator

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-any.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-any.hpp
@@ -99,14 +99,15 @@ public:
 template <class Predicate>
 inline auto exists(Predicate test)
 ->      detail::any_factory<Predicate> {
-    return  detail::any_factory<Predicate>(test);
+return  detail::any_factory<Predicate>(test);
 }
 
 template <class T>
 inline auto contains(T value)
-->      detail::any_factory<std::function<bool(T)>> {
-    return  detail::any_factory<std::function<bool(T)>>([value](T n) { return n == value; });
+->      detail::any_factory<decltype(std::bind(std::equal_to<T>(), std::placeholders::_1, T{}))> {
+return  detail::any_factory<decltype(std::bind(std::equal_to<T>(), std::placeholders::_1, T{}))>(std::bind(std::equal_to<T>(), std::placeholders::_1, value));
 }
+
 }
 
 }

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -758,10 +758,10 @@ public:
     */
     auto contains(T value) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(EXPLICIT_THIS lift<bool>(rxo::detail::any<T, std::function<bool(T)>>(std::function<bool(T)>{})))
+        -> decltype(EXPLICIT_THIS lift<bool>(rxo::detail::any<T, decltype(std::bind(std::equal_to<T>(), std::placeholders::_1, T{}))>(std::bind(std::equal_to<T>(), std::placeholders::_1, T{}))))
         /// \endcond
     {
-        return                    lift<bool>(rxo::detail::any<T, std::function<bool(T)>>([value](T n) { return n == value; }));
+        return                    lift<bool>(rxo::detail::any<T, decltype(std::bind(std::equal_to<T>(), std::placeholders::_1, T{}))>(std::bind(std::equal_to<T>(), std::placeholders::_1, value)));
     }
 
     /*! For each item from this observable use Predicate to select which items to emit from the new observable that is returned.


### PR DESCRIPTION
Replaced `lambda + std::function cast` to `std::bind + std::equal_to` to avoid a virtual function call. Not sure if that is the right way.. Please reject it if it is not right.

Please review.

Thank you,
Grigoriy
