### PR TITLE
Exposed empty as a source

### DIFF
--- a/Rx/v2/examples/doxygen/empty.cpp
+++ b/Rx/v2/examples/doxygen/empty.cpp
@@ -23,3 +23,15 @@ SCENARIO("threaded empty sample"){
             [](){printf("OnCompleted\n");});
     printf("//! [threaded empty sample]\n");
 }
+
+SCENARIO("empty operator syntax sample"){
+    using namespace rxcpp::sources;
+
+    printf("//! [empty operator syntax sample]\n");
+    auto values = empty<int>();
+    values.
+            subscribe(
+            [](int v){printf("OnNext: %d\n", v);},
+            [](){printf("OnCompleted\n");});
+    printf("//! [empty operator syntax sample]\n");
+}

--- a/Rx/v2/src/rxcpp/rx-sources.hpp
+++ b/Rx/v2/src/rxcpp/rx-sources.hpp
@@ -39,6 +39,7 @@ namespace rxs=sources;
 #include "sources/rx-range.hpp"
 #include "sources/rx-iterate.hpp"
 #include "sources/rx-interval.hpp"
+#include "sources/rx-empty.hpp"
 #include "sources/rx-defer.hpp"
 #include "sources/rx-never.hpp"
 #include "sources/rx-error.hpp"

--- a/Rx/v2/src/rxcpp/sources/rx-empty.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-empty.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+#pragma once
+
+#if !defined(RXCPP_SOURCES_RX_EMPTY_HPP)
+#define RXCPP_SOURCES_RX_EMPTY_HPP
+
+#include "../rx-includes.hpp"
+
+namespace rxcpp {
+
+namespace sources {
+
+template<class T>
+auto empty()
+    -> decltype(from<T>()) {
+    return      from<T>();
+}
+template<class T, class Coordination>
+auto empty(Coordination cn)
+    -> decltype(from<T>(std::move(cn))) {
+    return      from<T>(std::move(cn));
+}
+
+}
+
+}
+
+#endif

--- a/Rx/v2/test/CMakeLists.txt
+++ b/Rx/v2/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_SOURCES
     ${TEST_DIR}/subjects/subject.cpp
     ${TEST_DIR}/sources/create.cpp
     ${TEST_DIR}/sources/defer.cpp
+    ${TEST_DIR}/sources/empty.cpp
     ${TEST_DIR}/sources/interval.cpp
     ${TEST_DIR}/sources/scope.cpp
     ${TEST_DIR}/sources/timer.cpp

--- a/Rx/v2/test/sources/empty.cpp
+++ b/Rx/v2/test/sources/empty.cpp
@@ -1,0 +1,58 @@
+#include "../test.h"
+
+SCENARIO("empty emits no items", "[empty][sources]"){
+    GIVEN("an empty source"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        WHEN("created"){
+
+            auto res = w.start(
+                []() {
+                    return rx::observable<>::empty<int>()
+                        // forget type to workaround lambda deduction bug on msvc 2013
+                        .as_dynamic();
+                }
+            );
+
+            THEN("the output only contains the completion message"){
+                auto required = rxu::to_vector({
+                    on.completed(200)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
+SCENARIO("empty emits no items (rx::sources)", "[empty][sources]"){
+    GIVEN("an empty source"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        WHEN("created"){
+            using namespace rx::sources;
+
+            auto res = w.start(
+                    []() {
+                        return empty<int>()
+                                // forget type to workaround lambda deduction bug on msvc 2013
+                                .as_dynamic();
+                    }
+            );
+
+            THEN("the output only contains the completion message"){
+                auto required = rxu::to_vector({
+                                                       on.completed(200)
+                                               });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
Exposed [empty](http://reactivex.io/documentation/operators/empty-never-throw.html) as a source.
Just for consistency with [never](https://github.com/Reactive-Extensions/RxCpp/blob/master/Rx/v2/src/rxcpp/sources/rx-never.hpp#L27) and [error](https://github.com/Reactive-Extensions/RxCpp/blob/master/Rx/v2/src/rxcpp/sources/rx-error.hpp#L90).

Please, review.

Thank you,
Grigoriy
