### PR TITLE
Verbose abort

### DIFF
--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -27,7 +27,7 @@ struct OnErrorEmpty
 {
     void operator()(std::exception_ptr) const {
         // error implicitly ignored, abort
-        abort();
+        std::terminate();
     }
 };
 struct OnErrorIgnore


### PR DESCRIPTION
Allow to have a verbose abort, something like "terminate called after throwing an instance of " instead of nothing