### PR TITLE
add sequence_equal operator

### DIFF
--- a/Rx/v2/examples/doxygen/sequence_equal.cpp
+++ b/Rx/v2/examples/doxygen/sequence_equal.cpp
@@ -1,0 +1,15 @@
+#include "rxcpp/rx.hpp"
+
+#include "rxcpp/rx-test.hpp"
+#include "catch.hpp"
+
+SCENARIO("sequence_equal sample"){
+    printf("//! [sequence_equal sample]\n");
+    auto source = rxcpp::observable<>::range(1, 3);
+    auto values = source.sequence_equal(rxcpp::observable<>::range(1, 3));
+    values.
+        subscribe(
+            [](bool v){ printf("OnNext: %s\n", v ? "true" : "false"); },
+            [](){ printf("OnCompleted\n");} );
+    printf("//! [sequence_equal sample]\n");
+}

--- a/Rx/v2/src/rxcpp/operators/rx-sequence_equal.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-sequence_equal.hpp
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+#pragma once
+
+#if !defined(RXCPP_OPERATORS_RX_SEQUENCE_EQUAL_HPP)
+#define RXCPP_OPERATORS_RX_SEQUENCE_EQUAL_HPP
+
+#include "../rx-includes.hpp"
+
+namespace rxcpp {
+
+namespace operators {
+
+namespace detail {
+
+template<class T, class Observable, class OtherObservable, class Coordination>
+struct sequence_equal : public operator_base<bool>
+{
+    typedef rxu::decay_t<Observable> source_type;
+    typedef rxu::decay_t<T> source_value_type;
+    typedef rxu::decay_t<OtherObservable> other_source_type;
+    typedef typename other_source_type::value_type other_source_value_type;
+    typedef rxu::decay_t<Coordination> coordination_type;
+    typedef typename coordination_type::coordinator_type coordinator_type;
+
+    struct values {
+        values(source_type s, other_source_type t, coordination_type sf)
+                : source(std::move(s))
+                , other(std::move(t))
+                , coordination(std::move(sf))
+        {
+        }
+
+        source_type source;
+        other_source_type other;
+        coordination_type coordination;
+    };
+
+    values initial;
+
+    sequence_equal(source_type s, other_source_type t, coordination_type sf)
+        : initial(std::move(s), std::move(t), std::move(sf))
+    {
+    }
+
+    template<class Subscriber>
+    void on_subscribe(Subscriber s) const {
+
+        typedef Subscriber output_type;
+
+        struct state_type
+            : public std::enable_shared_from_this<state_type>
+            , public values
+        {
+            state_type(const values& vals, coordinator_type coor, const output_type& o)
+                : values(vals)
+                , coordinator(std::move(coor))
+                , out(o)
+                , source_completed(false)
+                , other_completed(false)
+            {
+                out.add(other_lifetime);
+                out.add(source_lifetime);
+            }
+
+            composite_subscription other_lifetime;
+            composite_subscription source_lifetime;
+            coordinator_type coordinator;
+            output_type out;
+            
+            mutable std::list<source_value_type> source_values;
+            mutable std::list<other_source_value_type> other_values;
+            mutable bool source_completed;
+            mutable bool other_completed;
+        };
+
+        auto coordinator = initial.coordination.create_coordinator();
+        auto state = std::make_shared<state_type>(initial, std::move(coordinator), std::move(s));
+
+        auto other = on_exception(
+            [&](){ return state->coordinator.in(state->other); },
+            state->out);
+        if (other.empty()) {
+            return;
+        }
+
+        auto source = on_exception(
+            [&](){ return state->coordinator.in(state->source); },
+            state->out);
+        if (source.empty()) {
+            return;
+        }
+
+        auto check_equal = [state]() {
+            if(!state->source_values.empty() && !state->other_values.empty()) {
+                auto x = std::move(state->source_values.front());
+                state->source_values.pop_front();
+
+                auto y = std::move(state->other_values.front());
+                state->other_values.pop_front();
+
+                if (x != y) {
+                    state->out.on_next(false);
+                    state->out.on_completed();
+                }
+            } else {
+                if((!state->source_values.empty() && state->other_completed) ||
+                   (!state->other_values.empty() && state->source_completed)) {
+                    state->out.on_next(false);
+                    state->out.on_completed();
+                }
+            }
+        };
+        
+        auto check_complete = [state]() {
+            if(state->source_completed && state->other_completed) {
+                state->out.on_next(state->source_values.empty() && state->other_values.empty());
+                state->out.on_completed();
+            }
+        };
+
+        auto sinkOther = make_subscriber<other_source_value_type>(
+            state->out,
+            state->other_lifetime,
+            // on_next
+            [state, check_equal](other_source_value_type t) {
+                auto& values = state->other_values;
+                values.push_back(t);
+                check_equal();
+            },
+            // on_error
+            [state](std::exception_ptr e) {
+                state->out.on_error(e);
+            },
+            // on_completed
+            [state, check_complete]() {
+                auto& completed = state->other_completed;
+                completed = true;
+                check_complete();
+            }
+        );
+
+        auto selectedSinkOther = on_exception(
+            [&](){ return state->coordinator.out(sinkOther); },
+            state->out);
+        if (selectedSinkOther.empty()) {
+            return;
+        }
+        other->subscribe(std::move(selectedSinkOther.get()));
+
+        source.get().subscribe(
+            state->source_lifetime,
+            // on_next
+            [state, check_equal](source_value_type t) {
+                auto& values = state->source_values;
+                values.push_back(t);
+                check_equal();
+            },
+            // on_error
+            [state](std::exception_ptr e) {
+                state->out.on_error(e);
+            },
+            // on_completed
+            [state, check_complete]() {
+                auto& completed = state->source_completed;
+                completed = true;
+                check_complete();
+            }
+        );        
+    }
+};
+
+template<class OtherObservable, class Coordination>
+class sequence_equal_factory
+{
+    typedef rxu::decay_t<OtherObservable> other_source_type;
+    typedef rxu::decay_t<Coordination> coordination_type;
+    
+    other_source_type other_source;
+    coordination_type coordination;
+    
+public:
+    sequence_equal_factory(other_source_type t, coordination_type sf)
+        : other_source(std::move(t))
+        , coordination(std::move(sf))
+    {
+    }
+    
+    template<class Observable>
+    auto operator()(Observable&& source)
+        ->      observable<bool, sequence_equal<rxu::value_type_t<rxu::decay_t<Observable>>, Observable, other_source_type, Coordination>> {
+        return  observable<bool, sequence_equal<rxu::value_type_t<rxu::decay_t<Observable>>, Observable, other_source_type, Coordination>>(
+                                 sequence_equal<rxu::value_type_t<rxu::decay_t<Observable>>, Observable, other_source_type, Coordination>(std::forward<Observable>(source), other_source, coordination));
+    }
+};
+
+}
+
+template<class OtherObservable>
+inline auto sequence_equal(OtherObservable&& t)
+    ->      detail::sequence_equal_factory<OtherObservable, identity_one_worker> {
+    return  detail::sequence_equal_factory<OtherObservable, identity_one_worker>(std::forward<OtherObservable>(t), identity_current_thread());
+}
+
+template<class OtherObservable, class Coordination>
+inline auto sequence_equal(OtherObservable&& t, Coordination&& sf)
+    ->      detail::sequence_equal_factory<OtherObservable, Coordination> {
+    return  detail::sequence_equal_factory<OtherObservable, Coordination>(std::forward<OtherObservable>(t), std::forward<Coordination>(sf));
+}   
+    
+}
+
+}
+
+#endif

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -864,6 +864,29 @@ public:
         return                  switch_if_empty(rxs::from(std::move(v)));
     }
 
+    /*! Determine whether two Observables emit the same sequence of items.
+
+        \tparam OtherSource  the type of the other observable.
+
+        \param t  the other Observable that emits items to compare.
+
+        \return  Observable that emits true only if both sequences terminate normally after emitting the same sequence of items in the same order; otherwise it will emit false.
+
+        \sample
+        \snippet sequence_equal.cpp sequence_equal sample
+        \snippet output.txt sequence_equal sample
+    */
+    template<class OtherSource>
+    auto sequence_equal(OtherSource&& t) const
+    /// \cond SHOW_SERVICE_MEMBERS
+    -> typename std::enable_if<is_observable<OtherSource>::value,
+                observable<bool, rxo::detail::sequence_equal<T, this_type, OtherSource, identity_one_worker>>>::type
+    /// \endcond
+    {
+        return  observable<bool, rxo::detail::sequence_equal<T, this_type, OtherSource, identity_one_worker>>(
+                rxo::detail::sequence_equal<T, this_type, OtherSource, identity_one_worker>(*this, std::forward<OtherSource>(t), identity_one_worker(rxsc::make_current_thread())));
+    }
+
     /*! inspect calls to on_next, on_error and on_completed.
 
         \tparam MakeObserverArgN...  these args are passed to make_observer

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -69,6 +69,7 @@ namespace rxo=operators;
 #include "operators/rx-retry.hpp"
 #include "operators/rx-sample_time.hpp"
 #include "operators/rx-scan.hpp"
+#include "operators/rx-sequence_equal.hpp"
 #include "operators/rx-skip.hpp"
 #include "operators/rx-skip_last.hpp"
 #include "operators/rx-skip_until.hpp"

--- a/Rx/v2/test/CMakeLists.txt
+++ b/Rx/v2/test/CMakeLists.txt
@@ -60,6 +60,7 @@ set(TEST_SOURCES
     ${TEST_DIR}/operators/retry.cpp
     ${TEST_DIR}/operators/sample.cpp
     ${TEST_DIR}/operators/scan.cpp
+    ${TEST_DIR}/operators/sequence_equal.cpp
     ${TEST_DIR}/operators/skip.cpp
     ${TEST_DIR}/operators/skip_last.cpp
     ${TEST_DIR}/operators/skip_until.cpp

--- a/Rx/v2/test/operators/sequence_equal.cpp
+++ b/Rx/v2/test/operators/sequence_equal.cpp
@@ -1,0 +1,696 @@
+#include "../test.h"
+
+SCENARIO("sequence_equal - source never emits", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(200, 2),
+            on.next(300, 3),
+            on.next(400, 4),
+            on.next(500, 5),
+            on.completed(600)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output is empty"){
+                auto required = std::vector<rxsc::test::messages<bool>::recorded_type>();
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 1000)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - other source never emits", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.next(310, 3),
+            on.next(410, 4),
+            on.next(510, 5),
+            on.completed(610)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 1)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output is empty"){
+                auto required = std::vector<rxsc::test::messages<bool>::recorded_type>();
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 610)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - both sources never emit any items", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 0),
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output is empty"){
+                auto required = std::vector<rxsc::test::messages<bool>::recorded_type>();
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 1000)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - both sources emit the same sequence of items", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.next(310, 3),
+            on.next(410, 4),
+            on.next(510, 5),
+            on.completed(610)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(220, 2),
+            on.next(330, 3),
+            on.next(440, 4),
+            on.next(550, 5),
+            on.completed(600)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains true"){
+                auto required = rxu::to_vector({
+                    o_on.next(610, true),
+                    o_on.completed(610)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 610)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - first source emits less items than the second one", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.next(310, 3),
+            on.next(410, 4),
+            on.completed(610)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(220, 2),
+            on.next(330, 3),
+            on.next(440, 4),
+            on.next(550, 5),
+            on.completed(600)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains false"){
+                auto required = rxu::to_vector({
+                    o_on.next(610, false),
+                    o_on.completed(610)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 610)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - second source emits less items than the first one", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.next(310, 3),
+            on.next(410, 4),
+            on.next(510, 5),
+            on.completed(610)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(220, 2),
+            on.next(330, 3),
+            on.next(440, 4),
+            on.completed(600)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains false"){
+                auto required = rxu::to_vector({
+                    o_on.next(610, false),
+                    o_on.completed(610)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 610)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - sources emit different sequence of items", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.next(310, 9), //
+            on.next(410, 4),
+            on.next(510, 5),
+            on.completed(610)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(220, 2),
+            on.next(330, 3),
+            on.next(440, 4),
+            on.next(550, 5),
+            on.completed(600)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains false"){
+                auto required = rxu::to_vector({
+                    o_on.next(330, false),
+                    o_on.completed(330)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 330)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - sources emit items in a different order", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.next(310, 3),
+            on.next(410, 4),
+            on.next(510, 5),
+            on.completed(610)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(220, 2),
+            on.next(330, 4),
+            on.next(440, 3),
+            on.next(550, 5),
+            on.completed(600)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains false"){
+                auto required = rxu::to_vector({
+                    o_on.next(330, false),
+                    o_on.completed(330)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 330)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - source observable is empty", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        auto xs = sc.make_hot_observable({
+            on.completed(250)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(220, 2),
+            on.next(330, 3),
+            on.completed(600)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains false"){
+                auto required = rxu::to_vector({
+                    o_on.next(330, false),
+                    o_on.completed(330)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - other observable is empty", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.next(310, 3),
+            on.completed(400)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.completed(250)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains false"){
+                auto required = rxu::to_vector({
+                    o_on.next(310, false),
+                    o_on.completed(310)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 310)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - both observables are empty", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        auto xs = sc.make_hot_observable({
+            on.completed(400)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.completed(250)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains false"){
+                auto required = rxu::to_vector({
+                    o_on.next(400, true),
+                    o_on.completed(400)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 400)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - source observable emits an error", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        std::runtime_error ex("sequence_equal error");
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.error(250, ex)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(220, 2),
+            on.next(550, 5),
+            on.completed(600)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains an error"){
+                auto required = rxu::to_vector({
+                    o_on.error(250, ex)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - other observable emits an error", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        std::runtime_error ex("sequence_equal error");
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.next(310, 3),
+            on.completed(400)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.next(150, 1),
+            on.error(250, ex)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains an error"){
+                auto required = rxu::to_vector({
+                    o_on.error(250, ex)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("sequence_equal - both observables emit errors", "[sequence_equal][operators]"){
+    GIVEN("two sources"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+        const rxsc::test::messages<bool> o_on;
+
+        std::runtime_error ex("sequence_equal error1");
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.error(250, ex)
+        });
+
+        auto ys = sc.make_hot_observable({
+            on.error(300, ex)
+        });
+
+        WHEN("two observables are checked for equality"){
+
+            auto res = w.start(
+                [xs, ys]() {
+                    return xs
+                            .sequence_equal(ys)
+                            .as_dynamic(); // forget type to workaround lambda deduction bug on msvc 2013
+                }
+            );
+
+            THEN("the output contains an error"){
+                auto required = rxu::to_vector({
+                    o_on.error(250, ex)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -61,6 +61,7 @@ set(RX_SOURCES
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/operators/rx-retry.hpp
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/operators/rx-sample_time.hpp
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/operators/rx-scan.hpp
+   ${RXCPP_DIR}/Rx/v2/src/rxcpp/operators/rx-sequence_equal.hpp
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/operators/rx-skip.hpp
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/operators/rx-skip_last.hpp
    ${RXCPP_DIR}/Rx/v2/src/rxcpp/operators/rx-skip_until.hpp

--- a/projects/doxygen/CMakeLists.txt
+++ b/projects/doxygen/CMakeLists.txt
@@ -88,6 +88,7 @@ if(DOXYGEN_FOUND)
         ${DOXY_EXAMPLES_SRC_DIR}/sample.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/scan.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/scope.cpp
+        ${DOXY_EXAMPLES_SRC_DIR}/sequence_equal.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/skip.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/skip_last.cpp
         ${DOXY_EXAMPLES_SRC_DIR}/skip_until.cpp


### PR DESCRIPTION
Added [sequence_equal](http://reactivex.io/documentation/operators/sequenceequal.html) operator.

In this commit, I used `!=` to check items for inequality.
Going to add a method with a binary predicate in one of the next commits.

Please, review.

Thank you,
Grigoriy
