### PR TITLE
add BinaryPredicate to sequence_equal

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-sequence_equal.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-sequence_equal.hpp
@@ -13,33 +13,36 @@ namespace operators {
 
 namespace detail {
 
-template<class T, class Observable, class OtherObservable, class Coordination>
+template<class T, class Observable, class OtherObservable, class BinaryPredicate, class Coordination>
 struct sequence_equal : public operator_base<bool>
 {
     typedef rxu::decay_t<Observable> source_type;
     typedef rxu::decay_t<T> source_value_type;
     typedef rxu::decay_t<OtherObservable> other_source_type;
     typedef typename other_source_type::value_type other_source_value_type;
+    typedef rxu::decay_t<BinaryPredicate> predicate_type;
     typedef rxu::decay_t<Coordination> coordination_type;
     typedef typename coordination_type::coordinator_type coordinator_type;
 
     struct values {
-        values(source_type s, other_source_type t, coordination_type sf)
+        values(source_type s, other_source_type t, predicate_type pred, coordination_type sf)
                 : source(std::move(s))
                 , other(std::move(t))
+                , pred(std::move(pred))
                 , coordination(std::move(sf))
         {
         }
 
         source_type source;
         other_source_type other;
+        predicate_type pred;
         coordination_type coordination;
     };
 
     values initial;
 
-    sequence_equal(source_type s, other_source_type t, coordination_type sf)
-        : initial(std::move(s), std::move(t), std::move(sf))
+    sequence_equal(source_type s, other_source_type t, predicate_type pred, coordination_type sf)
+        : initial(std::move(s), std::move(t), std::move(pred), std::move(sf))
     {
     }
 
@@ -99,7 +102,7 @@ struct sequence_equal : public operator_base<bool>
                 auto y = std::move(state->other_values.front());
                 state->other_values.pop_front();
 
-                if (x != y) {
+                if (!state->pred(x, y)) {
                     state->out.on_next(false);
                     state->out.on_completed();
                 }
@@ -170,27 +173,30 @@ struct sequence_equal : public operator_base<bool>
     }
 };
 
-template<class OtherObservable, class Coordination>
+template<class OtherObservable, class BinaryPredicate, class Coordination>
 class sequence_equal_factory
 {
     typedef rxu::decay_t<OtherObservable> other_source_type;
     typedef rxu::decay_t<Coordination> coordination_type;
+    typedef rxu::decay_t<BinaryPredicate> predicate_type;
     
     other_source_type other_source;
     coordination_type coordination;
+    predicate_type pred;
     
 public:
-    sequence_equal_factory(other_source_type t, coordination_type sf)
+    sequence_equal_factory(other_source_type t, predicate_type p, coordination_type sf)
         : other_source(std::move(t))
         , coordination(std::move(sf))
+        , pred(std::move(p))
     {
     }
     
     template<class Observable>
     auto operator()(Observable&& source)
-        ->      observable<bool, sequence_equal<rxu::value_type_t<rxu::decay_t<Observable>>, Observable, other_source_type, Coordination>> {
-        return  observable<bool, sequence_equal<rxu::value_type_t<rxu::decay_t<Observable>>, Observable, other_source_type, Coordination>>(
-                                 sequence_equal<rxu::value_type_t<rxu::decay_t<Observable>>, Observable, other_source_type, Coordination>(std::forward<Observable>(source), other_source, coordination));
+        ->      observable<bool, sequence_equal<rxu::value_type_t<rxu::decay_t<Observable>>, Observable, other_source_type, BinaryPredicate, Coordination>> {
+        return  observable<bool, sequence_equal<rxu::value_type_t<rxu::decay_t<Observable>>, Observable, other_source_type, BinaryPredicate, Coordination>>(
+                                 sequence_equal<rxu::value_type_t<rxu::decay_t<Observable>>, Observable, other_source_type, BinaryPredicate, Coordination>(std::forward<Observable>(source), other_source, pred, coordination));
     }
 };
 
@@ -198,16 +204,16 @@ public:
 
 template<class OtherObservable>
 inline auto sequence_equal(OtherObservable&& t)
-    ->      detail::sequence_equal_factory<OtherObservable, identity_one_worker> {
-    return  detail::sequence_equal_factory<OtherObservable, identity_one_worker>(std::forward<OtherObservable>(t), identity_current_thread());
+    ->      detail::sequence_equal_factory<OtherObservable, rxu::equal_to<>, identity_one_worker> {
+    return  detail::sequence_equal_factory<OtherObservable, rxu::equal_to<>, identity_one_worker>(std::forward<OtherObservable>(t), rxu::equal_to<>(), identity_current_thread());
 }
 
-template<class OtherObservable, class Coordination>
-inline auto sequence_equal(OtherObservable&& t, Coordination&& sf)
-    ->      detail::sequence_equal_factory<OtherObservable, Coordination> {
-    return  detail::sequence_equal_factory<OtherObservable, Coordination>(std::forward<OtherObservable>(t), std::forward<Coordination>(sf));
-}   
-    
+template<class OtherObservable, class BinaryPredicate>
+inline auto sequence_equal(OtherObservable&& t, BinaryPredicate&& pred)
+    ->      detail::sequence_equal_factory<OtherObservable, BinaryPredicate, identity_one_worker> {
+    return  detail::sequence_equal_factory<OtherObservable, BinaryPredicate, identity_one_worker>(std::forward<OtherObservable>(t), std::forward<BinaryPredicate>(pred));
+}
+
 }
 
 }

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -870,6 +870,31 @@ public:
 
     /*! Determine whether two Observables emit the same sequence of items.
 
+        \tparam OtherSource      the type of the other observable.
+        \tparam BinaryPredicate  the type of the value comparing function. The signature should be equivalent to the following: bool pred(const T1& a, const T2& b);
+
+        \param t     the other Observable that emits items to compare.
+        \param pred  the function that implements comparison of two values.
+
+        \return  Observable that emits true only if both sequences terminate normally after emitting the same sequence of items in the same order; otherwise it will emit false.
+
+        \sample
+        \snippet sequence_equal.cpp sequence_equal sample
+        \snippet output.txt sequence_equal sample
+    */
+    template<class OtherSource, class BinaryPredicate>
+    auto sequence_equal(OtherSource&& t, BinaryPredicate&& pred) const
+    /// \cond SHOW_SERVICE_MEMBERS
+    -> typename std::enable_if<is_observable<OtherSource>::value,
+                observable<bool, rxo::detail::sequence_equal<T, this_type, OtherSource, BinaryPredicate, identity_one_worker>>>::type
+    /// \endcond
+    {
+        return  observable<bool, rxo::detail::sequence_equal<T, this_type, OtherSource, BinaryPredicate, identity_one_worker>>(
+                rxo::detail::sequence_equal<T, this_type, OtherSource, BinaryPredicate, identity_one_worker>(*this, std::forward<OtherSource>(t), std::forward<BinaryPredicate>(pred), identity_one_worker(rxsc::make_current_thread())));
+    }
+
+    /*! Determine whether two Observables emit the same sequence of items.
+
         \tparam OtherSource  the type of the other observable.
 
         \param t  the other Observable that emits items to compare.
@@ -884,11 +909,11 @@ public:
     auto sequence_equal(OtherSource&& t) const
     /// \cond SHOW_SERVICE_MEMBERS
     -> typename std::enable_if<is_observable<OtherSource>::value,
-                observable<bool, rxo::detail::sequence_equal<T, this_type, OtherSource, identity_one_worker>>>::type
+                observable<bool, rxo::detail::sequence_equal<T, this_type, OtherSource, rxu::equal_to<>, identity_one_worker>>>::type
     /// \endcond
     {
-        return  observable<bool, rxo::detail::sequence_equal<T, this_type, OtherSource, identity_one_worker>>(
-                rxo::detail::sequence_equal<T, this_type, OtherSource, identity_one_worker>(*this, std::forward<OtherSource>(t), identity_one_worker(rxsc::make_current_thread())));
+        return  observable<bool, rxo::detail::sequence_equal<T, this_type, OtherSource, rxu::equal_to<>, identity_one_worker>>(
+                rxo::detail::sequence_equal<T, this_type, OtherSource, rxu::equal_to<>, identity_one_worker>(*this, std::forward<OtherSource>(t), rxu::equal_to<>(), identity_one_worker(rxsc::make_current_thread())));
     }
 
     /*! inspect calls to on_next, on_error and on_completed.
@@ -897,7 +922,7 @@ public:
 
         \param an  these args are passed to make_observer.
 
-        \return  Observable that emits the same items as the source observable to both the subscriber and the observer. 
+        \return  Observable that emits the same items as the source observable to both the subscriber and the observer.
 
         \note If an on_error method is not supplied the observer will ignore errors rather than call std::abort()
 
@@ -1093,7 +1118,7 @@ public:
         \param s  the selector function
 
         \return  Observable that emits the items from the source observable, transformed by the specified function.
-        
+
         \sample
         \snippet map.cpp map sample
         \snippet output.txt map sample
@@ -1194,7 +1219,7 @@ public:
     {
         return                    lift<T>(rxo::detail::delay<T, Duration, identity_one_worker>(period, identity_current_thread()));
     }
-       
+
     /*! For each item from this observable, filter out repeated values and emit only items that have not already been emitted.
 
         \return  Observable that emits those items from the source observable that are distinct.
@@ -1426,7 +1451,7 @@ public:
         \tparam ClosingSelector a function of type observable<CT>(OT)
         \tparam Coordination    the type of the scheduler
 
-        \param opens         each value from this observable opens a new window. 
+        \param opens         each value from this observable opens a new window.
         \param closes        this function is called for each opened window and returns an observable. the first value from the returned observable will close the window
         \param coordination  the scheduler for the windows
 
@@ -1450,7 +1475,7 @@ public:
         \tparam Openings        observable<OT>
         \tparam ClosingSelector a function of type observable<CT>(OT)
 
-        \param opens         each value from this observable opens a new window. 
+        \param opens         each value from this observable opens a new window.
         \param closes        this function is called for each opened window and returns an observable. the first value from the returned observable will close the window
 
         \return  Observable that emits an observable for each opened window.

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -370,6 +370,21 @@ struct less
         { return std::forward<LHS>(lhs) < std::forward<RHS>(rhs); }
 };
 
+template<class T = void>
+struct equal_to
+{
+    bool operator()(const T& lhs, const T& rhs) const { return lhs == rhs; }
+};
+
+template<>
+struct equal_to<void>
+{
+    template<class LHS, class RHS>
+    auto operator()(LHS&& lhs, RHS&& rhs) const
+    -> decltype(std::forward<LHS>(lhs) == std::forward<RHS>(rhs))
+    { return std::forward<LHS>(lhs) == std::forward<RHS>(rhs); }
+};
+
 namespace detail {
 template<class OStream, class Delimit>
 struct print_function


### PR DESCRIPTION
Introduced a helper function `equal_to` in rx-util.hpp that is used if no binary predicate is provided.
Added BinaryPredicate to sequence_equal.
Changed comparison to:
```
-                if (x != y) {
+                if (!state->pred(x, y)) {
```

Please, review.

Thank you,
Grigoriy
