### PR TITLE
Decouple filter from observable

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-filter.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-filter.hpp
@@ -95,20 +95,6 @@ struct filter
     }
 };
 
-template<class Predicate>
-class filter_factory
-{
-    typedef rxu::decay_t<Predicate> test_type;
-    test_type predicate;
-public:
-    filter_factory(test_type p) : predicate(std::move(p)) {}
-    template<class Observable>
-    auto operator()(Observable&& source)
-        -> decltype(source.template lift<rxu::value_type_t<rxu::decay_t<Observable>>>(filter<rxu::value_type_t<rxu::decay_t<Observable>>, test_type>(predicate))) {
-        return      source.template lift<rxu::value_type_t<rxu::decay_t<Observable>>>(filter<rxu::value_type_t<rxu::decay_t<Observable>>, test_type>(predicate));
-    }
-};
-
 }
 
 /*! @copydoc rx-filter.hpp

--- a/Rx/v2/src/rxcpp/operators/rx-filter.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-filter.hpp
@@ -2,6 +2,21 @@
 
 #pragma once
 
+/*! \file rx-filter.hpp
+
+    \brief For each item from this observable use Predicate to select which items to emit from the new observable that is returned.
+
+    \tparam Predicate  the type of the filter function
+
+    \param p  the filter function
+
+    \return  Observable that emits only those items emitted by the source observable that the filter evaluates as true.
+
+    \sample
+    \snippet filter.cpp filter sample
+    \snippet output.txt filter sample
+*/
+
 #if !defined(RXCPP_OPERATORS_RX_FILTER_HPP)
 #define RXCPP_OPERATORS_RX_FILTER_HPP
 
@@ -12,6 +27,16 @@ namespace rxcpp {
 namespace operators {
 
 namespace detail {
+
+template<class... AN>
+struct filter_invalid_arguments {};
+
+template<class... AN>
+struct filter_invalid : public rxo::operator_base<filter_invalid_arguments<AN...>> {
+    using type = observable<filter_invalid_arguments<AN...>, filter_invalid<AN...>>;
+};
+template<class... AN>
+using filter_invalid_t = typename filter_invalid<AN...>::type;
 
 template<class T, class Predicate>
 struct filter
@@ -58,7 +83,7 @@ struct filter
             dest.on_completed();
         }
 
-        static subscriber<value_type, observer<value_type, this_type>> make(dest_type d, test_type t) {
+        static subscriber<value_type, observer_type> make(dest_type d, test_type t) {
             return make_subscriber<value_type>(d, this_type(d, std::move(t)));
         }
     };
@@ -86,13 +111,34 @@ public:
 
 }
 
-template<class Predicate>
-auto filter(Predicate&& p)
-    ->      detail::filter_factory<Predicate> {
-    return  detail::filter_factory<Predicate>(std::forward<Predicate>(p));
+/*! @copydoc rx-filter.hpp
+*/
+template<class... AN>
+auto filter(AN&&... an)
+    ->      operator_factory<filter_tag, AN...> {
+     return operator_factory<filter_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
 }
 
 }
+
+template<>
+struct member_overload<filter_tag>
+{
+    template<class Observable, class Predicate,
+        class SourceValue = rxu::value_type_t<Observable>,
+        class Filter = rxo::detail::filter<SourceValue, rxu::decay_t<Predicate>>>
+    static auto member(Observable&& o, Predicate&& p)
+        -> decltype(o.template lift<SourceValue>(Filter(std::forward<Predicate>(p)))) {
+        return      o.template lift<SourceValue>(Filter(std::forward<Predicate>(p)));
+    }
+
+    template<class... AN>
+    static operators::detail::filter_invalid_t<AN...> member(const AN&...) {
+        std::terminate();
+        return {};
+        static_assert(sizeof...(AN) == 10000, "filter takes (Predicate)");
+    }
+};
 
 }
 

--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -184,6 +184,7 @@
 #if !defined(RXCPP_LITE)
 #include "operators/rx-combine_latest.hpp"
 #include "operators/rx-debounce.hpp"
+#include "operators/rx-filter.hpp"
 #include "operators/rx-group_by.hpp"
 #include "operators/rx-reduce.hpp"
 #include "operators/rx-with_latest_from.hpp"

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -800,25 +800,15 @@ public:
         static_assert(sizeof...(AN) == 0, "contains(value) was passed too many arguments.");
     }
 
-    /*! For each item from this observable use Predicate to select which items to emit from the new observable that is returned.
-
-        \tparam Predicate  the type of the filter function
-
-        \param p  the filter function
-
-        \return  Observable that emits only those items emitted by the source observable that the filter evaluates as true.
-
-        \sample
-        \snippet filter.cpp filter sample
-        \snippet output.txt filter sample
-    */
-    template<class Predicate>
-    auto filter(Predicate p) const
-        /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(EXPLICIT_THIS lift<T>(rxo::detail::filter<T, Predicate>(std::move(p))))
-        /// \endcond
+    /*! @copydoc rx-filter.hpp
+     */
+    template<class... AN>
+    auto filter(AN&&... an) const
+    /// \cond SHOW_SERVICE_MEMBERS
+    -> decltype(observable_member(filter_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    /// \endcond
     {
-        return                    lift<T>(rxo::detail::filter<T, Predicate>(std::move(p)));
+        return  observable_member(filter_tag{}, *this,                std::forward<AN>(an)...);
     }
 
     /*! If the source Observable terminates without emitting any items, emits items from a backup Observable.

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -108,7 +108,6 @@ public:
 #include "operators/rx-distinct.hpp"
 #include "operators/rx-distinct_until_changed.hpp"
 #include "operators/rx-element_at.hpp"
-#include "operators/rx-filter.hpp"
 #include "operators/rx-finally.hpp"
 #include "operators/rx-flat_map.hpp"
 #include "operators/rx-ignore_elements.hpp"
@@ -160,6 +159,13 @@ struct debounce_tag {
     template<class Included>
     struct include_header{
         static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-debounce.hpp>");
+    };
+};
+
+struct filter_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-filter.hpp>");
     };
 };
 

--- a/Rx/v2/test/operators/concat_map.cpp
+++ b/Rx/v2/test/operators/concat_map.cpp
@@ -1,5 +1,6 @@
 #include "../test.h"
 #include <rxcpp/operators/rx-reduce.hpp>
+#include <rxcpp/operators/rx-filter.hpp>
 
 static const int static_tripletCount = 100;
 

--- a/Rx/v2/test/operators/filter.cpp
+++ b/Rx/v2/test/operators/filter.cpp
@@ -43,27 +43,13 @@ SCENARIO("filter stops on completion", "[filter][operators]"){
         WHEN("filtered to ints that are primes"){
             auto res = w.start(
                 [&xs, &invoked]() {
-#if 0 && RXCPP_USE_OBSERVABLE_MEMBERS
                     return xs
-                        .filter([&invoked](int x) {
+                        | rxo::filter([&invoked](int x) {
                             invoked++;
                             return IsPrime(x);
                         })
                         // forget type to workaround lambda deduction bug on msvc 2013
-                        .as_dynamic();
-#else
-                    return xs
-                        >> rxo::filter([&invoked](int x) {
-                            invoked++;
-                            return IsPrime(x);
-                        })
-                        // demonstrates insertion of user definied operator
-                        >> [](rx::observable<int> o)->rx::observable<int>{
-                            return rxo::filter([](int){return true;})(o);
-                        }
-                        // forget type to workaround lambda deduction bug on msvc 2013
-                        >> rxo::as_dynamic();
-#endif
+                        | rxo::as_dynamic();
                 }
             );
             THEN("the output only contains primes"){
@@ -121,7 +107,6 @@ SCENARIO("filter stops on disposal", "[where][filter][operators]"){
 
             auto res = w.start(
                 [&xs, &invoked]() {
-#if RXCPP_USE_OBSERVABLE_MEMBERS
                     return xs
                         .filter([&invoked](int x) {
                             invoked++;
@@ -129,15 +114,6 @@ SCENARIO("filter stops on disposal", "[where][filter][operators]"){
                         })
                         // forget type to workaround lambda deduction bug on msvc 2013
                         .as_dynamic();
-#else
-                    return xs
-                        >> rxo::filter([&invoked](int x) {
-                            invoked++;
-                            return IsPrime(x);
-                        })
-                        // forget type to workaround lambda deduction bug on msvc 2013
-                        >> rxo::as_dynamic();
-#endif
                 },
                 400
             );
@@ -199,7 +175,6 @@ SCENARIO("filter stops on error", "[where][filter][operators]"){
 
             auto res = w.start(
                 [xs, &invoked]() {
-#if RXCPP_USE_OBSERVABLE_MEMBERS
                     return xs
                         .filter([&invoked](int x) {
                             invoked++;
@@ -207,15 +182,6 @@ SCENARIO("filter stops on error", "[where][filter][operators]"){
                         })
                         // forget type to workaround lambda deduction bug on msvc 2013
                         .as_dynamic();
-#else
-                    return xs
-                        >> rxo::filter([&invoked](int x) {
-                            invoked++;
-                            return IsPrime(x);
-                        })
-                        // forget type to workaround lambda deduction bug on msvc 2013
-                        >> rxo::as_dynamic();
-#endif
                 }
             );
 
@@ -278,7 +244,6 @@ SCENARIO("filter stops on throw from predicate", "[where][filter][operators]"){
 
             auto res = w.start(
                 [ex, xs, &invoked]() {
-#if RXCPP_USE_OBSERVABLE_MEMBERS
                     return xs
                         .filter([ex, &invoked](int x) {
                             invoked++;
@@ -289,18 +254,6 @@ SCENARIO("filter stops on throw from predicate", "[where][filter][operators]"){
                         })
                         // forget type to workaround lambda deduction bug on msvc 2013
                         .as_dynamic();
-#else
-                    return xs
-                        >> rxo::filter([ex, &invoked](int x) {
-                            invoked++;
-                            if (x > 5) {
-                                throw ex;
-                            }
-                            return IsPrime(x);
-                        })
-                        // forget type to workaround lambda deduction bug on msvc 2013
-                        >> rxo::as_dynamic();
-#endif
                 }
             );
 
@@ -363,7 +316,6 @@ SCENARIO("filter stops on dispose from predicate", "[where][filter][operators]")
 
             w.schedule_absolute(rxsc::test::created_time,
                 [&invoked, &res, &ys, &xs](const rxsc::schedulable&) {
-#if RXCPP_USE_OBSERVABLE_MEMBERS
                     ys = xs
                         .filter([&invoked, &res](int x) {
                             invoked++;
@@ -371,15 +323,6 @@ SCENARIO("filter stops on dispose from predicate", "[where][filter][operators]")
                                 res.unsubscribe();
                             return IsPrime(x);
                         });
-#else
-                    ys = xs
-                        >> rxo::filter([&invoked, &res](int x) {
-                            invoked++;
-                            if (x == 8)
-                                res.unsubscribe();
-                            return IsPrime(x);
-                        });
-#endif
                 });
 
             w.schedule_absolute(rxsc::test::subscribed_time, [&ys, &res](const rxsc::schedulable&) {

--- a/Rx/v2/test/operators/filter.cpp
+++ b/Rx/v2/test/operators/filter.cpp
@@ -1,5 +1,5 @@
 #include "../test.h"
-
+#include <rxcpp/operators/rx-filter.hpp>
 
 namespace {
 bool IsPrime(int x)

--- a/Rx/v2/test/operators/flat_map.cpp
+++ b/Rx/v2/test/operators/flat_map.cpp
@@ -1,5 +1,6 @@
 #include "../test.h"
 #include <rxcpp/operators/rx-reduce.hpp>
+#include <rxcpp/operators/rx-filter.hpp>
 
 static const int static_tripletCount = 100;
 


### PR DESCRIPTION
Decoupled `filter` from `observable` without implementation changes.
Please, review.

btw,
It might be better to extract [these](https://github.com/Reactive-Extensions/RxCpp/blob/master/Rx/v2/test/operators/filter.cpp#L46-L66) conditional testing into separate tests without `#if`. In this way both cases will be verified. I can make a separate PR if you wish.

Thank you,
Grigoriy