### PR TITLE
Interactive Sum

### DIFF
--- a/Ix/CPP/src/cpplinq/linq.hpp
+++ b/Ix/CPP/src/cpplinq/linq.hpp
@@ -471,7 +471,25 @@ public:
 
     // TODO: skip_while(pred)
 
-    // TODO: sum
+    template<typename ITEM = typename element_type>
+    typename std::enable_if<std::is_default_constructible<ITEM>::value, ITEM>::type sum() const {
+        ITEM seed{};
+        return sum(seed);
+    }
+
+    typename element_type sum(typename element_type seed) const {
+        return std::accumulate(begin(), end(), seed);
+    }
+
+    template <typename Selector, typename Result = std::result_of<Selector(typename element_type)>::type>
+    typename std::enable_if<std::is_default_constructible<Result>::value, Result>::type sum(Selector sel) const {
+        return from(begin(), end()).select(sel).sum();			
+    }
+
+    template <typename Selector, typename Result = std::result_of<Selector(typename element_type)>::type>
+    Result sum(Selector sel, Result seed) const {
+        return from(begin(), end()).select(sel).sum(seed);			
+    }
 
     linq_driver<linq_take<Collection>> take(std::size_t n) const {
         return linq_take<Collection>(c, n);

--- a/Ix/CPP/unittest/testbench.cpp
+++ b/Ix/CPP/unittest/testbench.cpp
@@ -8,6 +8,7 @@
 #include <numeric>
 #include <iterator>
 #include <string>
+#include <complex>
 
 #include <ctime>
 #include <cstddef>
@@ -511,6 +512,87 @@ TEST(test_performance)
     test_perf(task);
     cout << endl;
 #endif
+}
+
+// SUM TESTS
+
+TEST(test_sum_ints)
+{
+    vector<int> numbers{1, 2, 3, 4, 5};
+
+	auto result = cpplinq::from(numbers);
+    auto r2 = result.sum();
+
+	VERIFY_EQ(15, r2);
+}
+
+TEST(test_sum_ints_with_seed)
+{
+    vector<int> numbers{1, 2, 3, 4, 5};
+
+	auto result = cpplinq::from(numbers).sum(10);
+
+	VERIFY_EQ(25, result);
+}
+
+TEST(test_sum_floats) {
+	vector<float> numbers{ 1.0f,2.0f,3.0f,4.0f,5.0f };
+
+	auto result = cpplinq::from(numbers).sum();
+
+	VERIFY_EQ(15.0f, result);
+}
+
+TEST(test_sum_doubles) {
+	vector<double> numbers { 1.0,2.0,3.0,4.0,5.0 };
+
+	auto result = cpplinq::from(numbers).sum();
+
+	VERIFY_EQ(15.0, result);
+}
+
+TEST(test_sum_complex) {
+	using namespace std::complex_literals;
+
+	vector<complex<double>> numbers{ 1i, 1.0 + 2i, 2.0 + 3i };
+
+	auto sum = cpplinq::from(numbers).sum();
+
+	VERIFY_EQ(3.0, sum.real());
+	VERIFY_EQ(6.0, sum.imag());
+}
+
+TEST(test_sum_with_projection_lambda) {
+	vector<tuple<int>> numbers { std::tuple<int>(0), std::tuple<int>(1), std::tuple<int>(2) };
+
+	auto result = cpplinq::from(numbers).sum([](std::tuple<int>& x){
+                return std::get<0>(x);
+        });
+
+	VERIFY_EQ(3.0, result);
+}
+
+TEST(test_sum_with_projection_lambda_and_seed) {
+	vector<tuple<int>> numbers { std::tuple<int>(0), std::tuple<int>(1), std::tuple<int>(2) };
+
+	auto result = cpplinq::from(numbers).sum([](std::tuple<int>& x){
+                return std::get<0>(x);
+        }, 10);
+
+	VERIFY_EQ(13.0, result);
+}
+
+int getValue(std::tuple<int> x)
+{
+    return std::get<0>(x);
+}
+
+TEST(test_sum_with_projection_function_pointer) {
+	vector<tuple<int>> numbers { std::tuple<int>(0), std::tuple<int>(1), std::tuple<int>(2) };
+
+	auto result = cpplinq::from(numbers).sum(getValue);
+
+	VERIFY_EQ(3.0, result);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Implementation of the Interactive Sum:
1 - sum() can be called on element_type that is default-constructable and summable;
2 - sum(seed) can be called on element_type that is summable;
3 - sum(selector) can be used with a callable that returns a default-constructable and summable type;
4 - sum(selector, seed) can be used with a callable that returns any summable type;