### PR TITLE
decouple distinct_until_changed from observable

### DIFF
--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -186,6 +186,7 @@
 #include "operators/rx-debounce.hpp"
 #include "operators/rx-delay.hpp"
 #include "operators/rx-distinct.hpp"
+#include "operators/rx-distinct_until_changed.hpp"
 #include "operators/rx-filter.hpp"
 #include "operators/rx-group_by.hpp"
 #include "operators/rx-reduce.hpp"

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -1206,22 +1206,15 @@ public:
         return  observable_member(distinct_tag{},                *this, std::forward<AN>(an)...);
     }
 
-    /*! For each item from this observable, filter out consequentially repeated values and emit only changes from the new observable that is returned.
-
-        \return  Observable that emits those items from the source observable that are distinct from their immediate predecessors.
-
-        \sample
-        \snippet distinct_until_changed.cpp distinct_until_changed sample
-        \snippet output.txt distinct_until_changed sample
-    */
+    /*! @copydoc rx-distinct_until_changed.hpp
+     */
     template<class... AN>
-    auto distinct_until_changed(AN**...) const
-        /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(EXPLICIT_THIS lift<T>(rxo::detail::distinct_until_changed<T>()))
-        /// \endcond
+    auto distinct_until_changed(AN&&... an) const
+    /// \cond SHOW_SERVICE_MEMBERS
+    -> decltype(observable_member(distinct_until_changed_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    /// \endcond
     {
-        return                    lift<T>(rxo::detail::distinct_until_changed<T>());
-        static_assert(sizeof...(AN) == 0, "distinct_until_changed() was passed too many arguments.");
+        return  observable_member(distinct_until_changed_tag{},                *this, std::forward<AN>(an)...);
     }
 
     /*! Pulls an item located at a specified index location in the sequence of items and emits that item as its own sole emission.

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -104,7 +104,6 @@ public:
 #include "operators/rx-concat.hpp"
 #include "operators/rx-concat_map.hpp"
 #include "operators/rx-connect_forever.hpp"
-#include "operators/rx-distinct_until_changed.hpp"
 #include "operators/rx-element_at.hpp"
 #include "operators/rx-finally.hpp"
 #include "operators/rx-flat_map.hpp"
@@ -171,6 +170,13 @@ struct distinct_tag {
     template<class Included>
     struct include_header{
         static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-distinct.hpp>");
+    };
+};
+
+struct distinct_until_changed_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-distinct_until_changed.hpp>");
     };
 };
 

--- a/Rx/v2/test/operators/distinct_until_changed.cpp
+++ b/Rx/v2/test/operators/distinct_until_changed.cpp
@@ -1,4 +1,5 @@
 #include "../test.h"
+#include <rxcpp/operators/rx-distinct_until_changed.hpp>
 
 SCENARIO("distinct_until_changed - never", "[distinct_until_changed][operators]"){
     GIVEN("a source"){
@@ -14,7 +15,7 @@ SCENARIO("distinct_until_changed - never", "[distinct_until_changed][operators]"
 
             auto res = w.start(
                 [xs]() {
-                    return xs.distinct_until_changed();
+                    return xs | rxo::distinct_until_changed();
                 }
             );
 


### PR DESCRIPTION
Decoupled distinct_until_changed from observable
No implementation changes.

Please review.

Thank you,
Grigoriy