### PR TITLE
fixes issue 284

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-distinct_until_changed.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-distinct_until_changed.hpp
@@ -54,7 +54,7 @@ struct distinct_until_changed
         {
         }
         void on_next(source_value_type v) const {
-            if (remembered.empty() || v != remembered.get()) {
+            if (remembered.empty() || !(v == remembered.get())) {
                 remembered.reset(v);
                 dest.on_next(v);
             }
@@ -96,8 +96,7 @@ struct member_overload<distinct_until_changed_tag>
     template<class Observable,
             class SourceValue = rxu::value_type_t<Observable>,
             class Enabled = rxu::enable_if_all_true_type_t<
-                is_observable<Observable>,
-                is_hashable<SourceValue>>,
+                is_observable<Observable>>,
             class DistinctUntilChanged = rxo::detail::distinct_until_changed<SourceValue>>
     static auto member(Observable&& o)
     -> decltype(o.template lift<SourceValue>(DistinctUntilChanged())) {

--- a/Rx/v2/test/operators/distinct_until_changed.cpp
+++ b/Rx/v2/test/operators/distinct_until_changed.cpp
@@ -298,3 +298,66 @@ SCENARIO("distinct_until_changed - some changes", "[distinct_until_changed][oper
         }
     }
 }
+
+struct A {
+    int i;
+
+    bool operator!=(const A& a) const {
+        return i != a.i;
+    }
+
+    bool operator==(const A& a) const {
+        return i == a.i;
+    }
+};
+
+SCENARIO("distinct_until_changed - custom type", "[distinct_until_changed][operators]"){
+    GIVEN("a source"){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<A> on;
+
+        auto xs = sc.make_hot_observable({
+            on.next(150, A{1}),
+            on.next(210, A{2}), //*
+            on.next(215, A{3}), //*
+            on.next(220, A{3}),
+            on.next(225, A{2}), //*
+            on.next(230, A{2}),
+            on.next(230, A{1}), //*
+            on.next(240, A{2}), //*
+            on.completed(250)
+        });
+
+        WHEN("distinct values are taken"){
+
+            auto res = w.start(
+                [xs]() {
+                    return xs.distinct_until_changed();
+                }
+            );
+
+            THEN("the output only contains distinct items sent while subscribed"){
+                auto required = rxu::to_vector({
+                    on.next(210, A{2}), //*
+                    on.next(215, A{3}), //*
+                    on.next(225, A{2}), //*
+                    on.next(230, A{1}), //*
+                    on.next(240, A{2}), //*
+                    on.completed(250)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = xs.subscriptions();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
A fix for #284 
distinct_until_changed:
* Removed the invalid requirement for a type to be hashable.
* `operator==` is used to determine if two elements are equal.
* added test