### PR TITLE
decouple on_error_resume_next from observable

### DIFF
--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -195,6 +195,7 @@
 #include "operators/rx-group_by.hpp"
 #include "operators/rx-ignore_elements.hpp"
 #include "operators/rx-map.hpp"
+#include "operators/rx-on_error_resume_next.hpp"
 #include "operators/rx-reduce.hpp"
 #include "operators/rx-with_latest_from.hpp"
 #include "operators/rx-zip.hpp"

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -1081,25 +1081,15 @@ public:
         return      observable_member(finally_tag{},                *this, std::forward<AN>(an)...);
     }
 
-    /*! If an error occurs, take the result from the Selector and subscribe to that instead.
-
-        \tparam Selector  the actual type of a function of the form `observable<T>(std::exception_ptr)`
-
-        \param s  the function of the form `observable<T>(std::exception_ptr)`
-
-        \return  Observable that emits the items from the source observable and switches to a new observable on error.
-
-        \sample
-        \snippet on_error_resume_next.cpp on_error_resume_next sample
-        \snippet output.txt on_error_resume_next sample
+    /*! @copydoc rx-on_error_resume_next.hpp
     */
-    template<class Selector>
-    auto on_error_resume_next(Selector s) const
-        /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(EXPLICIT_THIS lift<rxu::value_type_t<rxo::detail::on_error_resume_next<T, Selector>>>(rxo::detail::on_error_resume_next<T, Selector>(std::move(s))))
-        /// \endcond
+    template<class... AN>
+    auto on_error_resume_next(AN&&... an) const
+    /// \cond SHOW_SERVICE_MEMBERS
+    -> decltype(observable_member(on_error_resume_next_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    /// \endcond
     {
-        return                    lift<rxu::value_type_t<rxo::detail::on_error_resume_next<T, Selector>>>(rxo::detail::on_error_resume_next<T, Selector>(std::move(s)));
+        return  observable_member(on_error_resume_next_tag{},                *this, std::forward<AN>(an)...);
     }
 
     /*! @copydoc rx-map.hpp

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -253,7 +253,7 @@ struct reduce_tag {
         static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-reduce.hpp>");
     };
 };
-struct first_tag  {};
+struct first_tag : reduce_tag {};
 struct last_tag : reduce_tag {};
 struct sum_tag : reduce_tag {};
 struct average_tag : reduce_tag {};

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -107,7 +107,6 @@ public:
 #include "operators/rx-merge.hpp"
 #include "operators/rx-multicast.hpp"
 #include "operators/rx-observe_on.hpp"
-#include "operators/rx-on_error_resume_next.hpp"
 #include "operators/rx-pairwise.hpp"
 #include "operators/rx-publish.hpp"
 #include "operators/rx-ref_count.hpp"
@@ -231,6 +230,13 @@ struct map_tag {
     template<class Included>
     struct include_header{
         static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-map.hpp>");
+    };
+};
+
+struct on_error_resume_next_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-on_error_resume_next.hpp>");
     };
 };
 

--- a/Rx/v2/test/operators/on_error_resume_next.cpp
+++ b/Rx/v2/test/operators/on_error_resume_next.cpp
@@ -1,4 +1,5 @@
 #include "../test.h"
+#include <rxcpp/operators/rx-on_error_resume_next.hpp>
 
 SCENARIO("on_error_resume_next stops on completion", "[on_error_resume_next][operators]"){
     GIVEN("a test hot observable of ints"){


### PR DESCRIPTION
Decoupled `on_error_resume_next` from observable.
In a separate commit made `first_tag` to inherit from `reduce_tag`.

Please, review.

Thank you,
Grigoriy
