### PR TITLE
decouple repeat from observable

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -2,6 +2,25 @@
 
 #pragma once
 
+/*! \file rx-repeat.hpp
+
+    \brief Repeat this observable for the given number of times or infinitely.
+
+    \tparam Count  the type of the counter (optional).
+
+    \param t  the number of times the source observable items are repeated (optional). If not specified or 0, infinitely repeats the source observable.
+
+    \return  An observable that repeats the sequence of items emitted by the source observable for t times.
+
+    \sample
+    \snippet repeat.cpp repeat count sample
+    \snippet output.txt repeat count sample
+
+    If the source observable calls on_error, repeat stops:
+    \snippet repeat.cpp repeat error sample
+    \snippet output.txt repeat error sample
+*/
+
 #if !defined(RXCPP_OPERATORS_RX_REPEAT_HPP)
 #define RXCPP_OPERATORS_RX_REPEAT_HPP
 
@@ -12,6 +31,16 @@ namespace rxcpp {
 namespace operators {
 
 namespace detail {
+
+template<class... AN>
+struct repeat_invalid_arguments {};
+
+template<class... AN>
+struct repeat_invalid : public rxo::operator_base<repeat_invalid_arguments<AN...>> {
+    using type = observable<repeat_invalid_arguments<AN...>, repeat_invalid<AN...>>;
+};
+template<class... AN>
+using repeat_invalid_t = typename repeat_invalid<AN...>::type;
 
 template<class T, class Observable, class Count>
 struct repeat : public operator_base<T>
@@ -95,31 +124,51 @@ struct repeat : public operator_base<T>
     }
 };
 
-template<class T>
-class repeat_factory
-{
-    typedef rxu::decay_t<T> count_type;
-    count_type count;
-public:
-    repeat_factory(count_type t) : count(std::move(t)) {}
+}
 
-    template<class Observable>
-    auto operator()(Observable&& source)
-        ->      observable<rxu::value_type_t<rxu::decay_t<Observable>>, repeat<rxu::value_type_t<rxu::decay_t<Observable>>, rxu::decay_t<Observable>, count_type>> {
-        return  observable<rxu::value_type_t<rxu::decay_t<Observable>>, repeat<rxu::value_type_t<rxu::decay_t<Observable>>, rxu::decay_t<Observable>, count_type>>(
-                                                                        repeat<rxu::value_type_t<rxu::decay_t<Observable>>, rxu::decay_t<Observable>, count_type>(std::forward<Observable>(source), count));
+/*! @copydoc rx-repeat.hpp
+*/
+template<class... AN>
+auto repeat(AN&&... an)
+->     operator_factory<repeat_tag, AN...> {
+    return operator_factory<repeat_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
+}
+
+}
+
+template<>
+struct member_overload<repeat_tag>
+{
+    template<class Observable,
+        class Enabled = rxu::enable_if_all_true_type_t<
+            is_observable<Observable>>,
+        class SourceValue = rxu::value_type_t<Observable>,
+        class Repeat = rxo::detail::repeat<SourceValue, rxu::decay_t<Observable>, int>,
+        class Value = rxu::value_type_t<Repeat>,
+        class Result = observable<Value, Repeat>>
+    static Result member(Observable&& o) {
+        return Result(Repeat(std::forward<Observable>(o), 0));
+    }
+
+    template<class Observable,
+        class Count,
+        class Enabled = rxu::enable_if_all_true_type_t<
+            is_observable<Observable>>,
+        class SourceValue = rxu::value_type_t<Observable>,
+        class Repeat = rxo::detail::repeat<SourceValue, rxu::decay_t<Observable>, rxu::decay_t<Count>>,
+        class Value = rxu::value_type_t<Repeat>,
+        class Result = observable<Value, Repeat>>
+    static Result member(Observable&& o, Count&& c) {
+        return Result(Repeat(std::forward<Observable>(o), std::forward<Count>(c)));
+    }
+
+    template<class... AN>
+    static operators::detail::repeat_invalid_t<AN...> member(const AN&...) {
+        std::terminate();
+        return {};
+        static_assert(sizeof...(AN) == 10000, "repeat takes (optional Count)");
     }
 };
-
-}
-
-template<class T>
-auto repeat(T&& t)
-    ->      detail::repeat_factory<T> {
-    return  detail::repeat_factory<T>(std::forward<T>(t));
-}
-
-}
 
 }
 

--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -163,7 +163,7 @@ struct member_overload<repeat_tag>
     }
 
     template<class... AN>
-    static operators::detail::repeat_invalid_t<AN...> member(const AN&...) {
+    static operators::detail::repeat_invalid_t<AN...> member(AN...) {
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "repeat takes (optional Count)");

--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -198,9 +198,10 @@
 #include "operators/rx-on_error_resume_next.hpp"
 #include "operators/rx-pairwise.hpp"
 #include "operators/rx-reduce.hpp"
+#include "operators/rx-repeat.hpp"
+#include "operators/rx-retry.hpp"
 #include "operators/rx-sequence_equal.hpp"
 #include "operators/rx-take_while.hpp"
-#include "operators/rx-retry.hpp"
 #include "operators/rx-with_latest_from.hpp"
 #include "operators/rx-zip.hpp"
 #endif

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -2873,51 +2873,15 @@ public:
         return  observable_member(take_while_tag{}, *this,                std::forward<AN>(an)...);
     }
 
-    /*! Infinitely repeat this observable.
-
-        \return  An observable that emits the items emitted by the source observable repeatedly and in sequence.
-
-        \sample
-        \snippet repeat.cpp repeat sample
-        \snippet output.txt repeat sample
-
-        If the source observable calls on_error, repeat stops:
-        \snippet repeat.cpp repeat error sample
-        \snippet output.txt repeat error sample
-    */
+    /*! @copydoc rx-repeat.hpp
+     */
     template<class... AN>
-    auto repeat(AN**...) const
+    auto repeat(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        ->      observable<T, rxo::detail::repeat<T, this_type, int>>
+        -> decltype(observable_member(repeat_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
         /// \endcond
     {
-        return  observable<T, rxo::detail::repeat<T, this_type, int>>(
-            rxo::detail::repeat<T, this_type, int>(*this, 0));
-        static_assert(sizeof...(AN) == 0, "repeat() was passed too many arguments.");
-    }
-
-    /*! Repeat this observable for the given number of times.
-
-        \tparam Count  the type of the counter
-
-        \param t  the number of times the source observable items are repeated
-
-        \return  An observable that repeats the sequence of items emitted by the source observable for t times.
-
-        Call to repeat(0) infinitely repeats the source observable.
-
-        \sample
-        \snippet repeat.cpp repeat count sample
-        \snippet output.txt repeat count sample
-    */
-    template<class Count>
-    auto repeat(Count t) const
-        /// \cond SHOW_SERVICE_MEMBERS
-        ->      observable<T, rxo::detail::repeat<T, this_type, Count>>
-        /// \endcond
-    {
-        return  observable<T, rxo::detail::repeat<T, this_type, Count>>(
-            rxo::detail::repeat<T, this_type, Count>(*this, t));
+        return      observable_member(repeat_tag{},                *this, std::forward<AN>(an)...);
     }
 
     /*! @copydoc rx-retry.hpp

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -109,7 +109,6 @@ public:
 #include "operators/rx-observe_on.hpp"
 #include "operators/rx-publish.hpp"
 #include "operators/rx-ref_count.hpp"
-#include "operators/rx-repeat.hpp"
 #include "operators/rx-replay.hpp"
 #include "operators/rx-sample_time.hpp"
 #include "operators/rx-scan.hpp"
@@ -269,6 +268,13 @@ struct pairwise_tag {
     template<class Included>
     struct include_header{
         static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-pairwise.hpp>");
+    };
+};
+
+struct repeat_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-repeat.hpp>");
     };
 };
 

--- a/Rx/v2/test/operators/repeat.cpp
+++ b/Rx/v2/test/operators/repeat.cpp
@@ -1,4 +1,6 @@
 #include "../test.h"
+#include "rxcpp/operators/rx-repeat.hpp"
+
 
 SCENARIO("repeat, basic test", "[repeat][operators]"){
     GIVEN("cold observable of 3 ints."){
@@ -18,9 +20,9 @@ SCENARIO("repeat, basic test", "[repeat][operators]"){
             auto res = w.start(
                 [&]() {
                     return xs
-                        .repeat()
+                        | rxo::repeat()
                         // forget type to workaround lambda deduction bug on msvc 2013
-                        .as_dynamic();
+                        | rxo::as_dynamic();
                 }
             );
 


### PR DESCRIPTION
A minor update.. Decoupled `repeat` from `observable`.
Please review.

Thank you,
Grigoriy
