### PR TITLE
decouple time_interval from observable

### DIFF
--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -203,6 +203,7 @@
 #include "operators/rx-retry.hpp"
 #include "operators/rx-sequence_equal.hpp"
 #include "operators/rx-take_while.hpp"
+#include "operators/rx-time_interval.hpp"
 #include "operators/rx-timestamp.hpp"
 #include "operators/rx-with_latest_from.hpp"
 #include "operators/rx-zip.hpp"

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -876,45 +876,15 @@ public:
         return                    lift<T>(rxo::detail::tap<T, std::tuple<MakeObserverArgN...>>(std::make_tuple(std::forward<MakeObserverArgN>(an)...)));
     }
 
-    /*! Returns an observable that emits indications of the amount of time lapsed between consecutive emissions of the source observable.
-        The first emission from this new Observable indicates the amount of time lapsed between the time when the observer subscribed to the Observable and the time when the source Observable emitted its first item.
-
-        \tparam Coordination  the type of the scheduler
-
-        \param coordination  the scheduler for itme intervals
-
-        \return  Observable that emits a time_duration to indicate the amount of time lapsed between pairs of emissions.
-
-        \sample
-        \snippet time_interval.cpp time_interval sample
-        \snippet output.txt time_interval sample
-    */
-    template<class Coordination>
-    auto time_interval(Coordination coordination) const
-    /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(EXPLICIT_THIS lift<rxsc::scheduler::clock_type::time_point::duration>(rxo::detail::time_interval<T, Coordination>{coordination}))
-    /// \endcond
-    {
-        return                lift<rxsc::scheduler::clock_type::time_point::duration>(rxo::detail::time_interval<T, Coordination>{coordination});
-    }
-
-    /*! Returns an observable that emits indications of the amount of time lapsed between consecutive emissions of the source observable.
-        The first emission from this new Observable indicates the amount of time lapsed between the time when the observer subscribed to the Observable and the time when the source Observable emitted its first item.
-
-        \return  Observable that emits a time_duration to indicate the amount of time lapsed between pairs of emissions.
-
-        \sample
-        \snippet time_interval.cpp time_interval sample
-        \snippet output.txt time_interval sample
-    */
+    /*! @copydoc rx-time_interval.hpp
+     */
     template<class... AN>
-    auto time_interval(AN**...) const
+    auto time_interval(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
-    -> decltype(EXPLICIT_THIS lift<rxsc::scheduler::clock_type::time_point::duration>(rxo::detail::time_interval<T, identity_one_worker>{identity_current_thread()}))
+    -> decltype(observable_member(time_interval_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
     /// \endcond
     {
-        return                lift<rxsc::scheduler::clock_type::time_point::duration>(rxo::detail::time_interval<T, identity_one_worker>{identity_current_thread()});
-        static_assert(sizeof...(AN) == 0, "time_interval() was passed too many arguments.");
+        return  observable_member(time_interval_tag{},                *this, std::forward<AN>(an)...);
     }
 
     /*! Return an observable that terminates with timeout_error if a particular timespan has passed without emitting another item from the source observable.

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -123,7 +123,6 @@ public:
 #include "operators/rx-take_last.hpp"
 #include "operators/rx-take_until.hpp"
 #include "operators/rx-tap.hpp"
-#include "operators/rx-time_interval.hpp"
 #include "operators/rx-timeout.hpp"
 #include "operators/rx-window.hpp"
 #include "operators/rx-window_time.hpp"
@@ -294,6 +293,13 @@ struct sequence_equal_tag {
     template<class Included>
     struct include_header{
         static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-sequence_equal.hpp>");
+    };
+};
+
+struct time_interval_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-time_interval.hpp>");
     };
 };
 

--- a/Rx/v2/test/operators/time_interval.cpp
+++ b/Rx/v2/test/operators/time_interval.cpp
@@ -1,4 +1,5 @@
 #include "../test.h"
+#include "rxcpp/operators/rx-time_interval.hpp"
 
 using namespace std::chrono;
 
@@ -18,7 +19,8 @@ SCENARIO("should not emit time intervals if the source never emits any items", "
 
             auto res = w.start(
                 [xs]() {
-                    return xs.time_interval();
+                    return xs
+                        | rxo::time_interval();
                 }
             );
 


### PR DESCRIPTION
A minor update -- decoupled `time_interval` from observable.
Please review.

Thank you,
Grigoriy
