### PR TITLE
decouple skip from observable

### DIFF
--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -204,6 +204,7 @@
 #include "operators/rx-repeat.hpp"
 #include "operators/rx-retry.hpp"
 #include "operators/rx-sequence_equal.hpp"
+#include "operators/rx-skip.hpp"
 #include "operators/rx-take.hpp"
 #include "operators/rx-take_while.hpp"
 #include "operators/rx-timeout.hpp"

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -2311,26 +2311,15 @@ public:
         static_assert(sizeof...(AN) == 0, "sample_with_time(period) was passed too many arguments.");
     }
 
-    /*! Make new observable with skipped first count items from this observable.
-
-        \tparam  Count  the type of the items counter
-
-        \param  t  the number of items to skip
-
-        \return  An observable that is identical to the source observable except that it does not emit the first t items that the source observable emits.
-
-        \sample
-        \snippet skip.cpp skip sample
-        \snippet output.txt skip sample
+    /*! @copydoc rx-skip.hpp
     */
-    template<class Count>
-    auto skip(Count t) const
-        /// \cond SHOW_SERVICE_MEMBERS
-        ->      observable<T,   rxo::detail::skip<T, this_type, Count>>
-        /// \endcond
+    template<class... AN>
+    auto skip(AN... an) const
+    /// \cond SHOW_SERVICE_MEMBERS
+    -> decltype(observable_member(skip_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    /// \endcond
     {
-        return  observable<T,   rxo::detail::skip<T, this_type, Count>>(
-                                rxo::detail::skip<T, this_type, Count>(*this, t));
+        return      observable_member(skip_tag{},                *this, std::forward<AN>(an)...);
     }
 
     /*! Make new observable with skipped last count items from this observable.

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -109,7 +109,6 @@ public:
 #include "operators/rx-replay.hpp"
 #include "operators/rx-sample_time.hpp"
 #include "operators/rx-scan.hpp"
-#include "operators/rx-skip.hpp"
 #include "operators/rx-skip_last.hpp"
 #include "operators/rx-skip_until.hpp"
 #include "operators/rx-start_with.hpp"
@@ -296,6 +295,13 @@ struct sequence_equal_tag {
     template<class Included>
     struct include_header{
         static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-sequence_equal.hpp>");
+    };
+};
+
+struct skip_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-skip.hpp>");
     };
 };
 

--- a/Rx/v2/test/operators/skip.cpp
+++ b/Rx/v2/test/operators/skip.cpp
@@ -1,4 +1,5 @@
 #include "../test.h"
+#include "rxcpp/operators/rx-skip.hpp"
 
 SCENARIO("skip, complete after", "[skip][operators]"){
     GIVEN("a source"){
@@ -93,9 +94,9 @@ SCENARIO("skip, complete same", "[skip][operators]"){
             auto res = w.start(
                 [xs]() {
                     return xs
-                        .skip(17)
+                        | rxo::skip(17)
                         // forget type to workaround lambda deduction bug on msvc 2013
-                        .as_dynamic();
+                        | rxo::as_dynamic();
                 }
             );
 


### PR DESCRIPTION
Since `take` has been already decoupled, it is high time to do the same with `skip`. 