### PR TITLE
decouple window_with_time_or_count from observable

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-buffer_time_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-buffer_time_count.hpp
@@ -2,7 +2,7 @@
 
 #pragma once
 
-/*! \file rx-buffer_with_time_or_count.hpp
+/*! \file rx-buffer_time_count.hpp
 
     \brief Return an observable that emits connected, non-overlapping buffers of items from the source observable that were emitted during a fixed duration of time or when the buffer has reached maximum capacity (whichever occurs first), on the specified scheduler.
 
@@ -263,7 +263,7 @@ struct member_overload<buffer_with_time_or_count_tag>
     }
 
     template<class... AN>
-    static operators::detail::buffer_count_invalid_t<AN...> member(AN...) {
+    static operators::detail::buffer_with_time_or_count_tag_invalid_t<AN...> member(AN...) {
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "buffer_with_time_or_count takes (Duration, Count, optional Coordination)");

--- a/Rx/v2/src/rxcpp/operators/rx-buffer_time_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-buffer_time_count.hpp
@@ -36,14 +36,14 @@ namespace operators {
 namespace detail {
 
 template<class... AN>
-struct buffer_with_time_or_count_tag_invalid_arguments {};
+struct buffer_with_time_or_count_invalid_arguments {};
 
 template<class... AN>
-struct buffer_with_time_or_count_tag_invalid : public rxo::operator_base<buffer_with_time_or_count_tag_invalid_arguments<AN...>> {
-    using type = observable<buffer_with_time_or_count_tag_invalid_arguments<AN...>, buffer_with_time_or_count_tag_invalid<AN...>>;
+struct buffer_with_time_or_count_invalid : public rxo::operator_base<buffer_with_time_or_count_invalid_arguments<AN...>> {
+    using type = observable<buffer_with_time_or_count_invalid_arguments<AN...>, buffer_with_time_or_count_invalid<AN...>>;
 };
 template<class... AN>
-using buffer_with_time_or_count_tag_invalid_t = typename buffer_with_time_or_count_tag_invalid<AN...>::type;
+using buffer_with_time_or_count_invalid_t = typename buffer_with_time_or_count_invalid<AN...>::type;
     
 template<class T, class Duration, class Coordination>
 struct buffer_with_time_or_count
@@ -263,7 +263,7 @@ struct member_overload<buffer_with_time_or_count_tag>
     }
 
     template<class... AN>
-    static operators::detail::buffer_with_time_or_count_tag_invalid_t<AN...> member(AN...) {
+    static operators::detail::buffer_with_time_or_count_invalid_t<AN...> member(AN...) {
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "buffer_with_time_or_count takes (Duration, Count, optional Coordination)");

--- a/Rx/v2/src/rxcpp/operators/rx-window_time_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_time_count.hpp
@@ -36,14 +36,14 @@ namespace operators {
 namespace detail {
 
 template<class... AN>
-struct window_with_time_or_count_tag_invalid_arguments {};
+struct window_with_time_or_count_invalid_arguments {};
 
 template<class... AN>
-struct window_with_time_or_count_tag_invalid : public rxo::operator_base<window_with_time_or_count_tag_invalid_arguments<AN...>> {
-    using type = observable<window_with_time_or_count_tag_invalid_arguments<AN...>, window_with_time_or_count_tag_invalid<AN...>>;
+struct window_with_time_or_count_invalid : public rxo::operator_base<window_with_time_or_count_invalid_arguments<AN...>> {
+    using type = observable<window_with_time_or_count_invalid_arguments<AN...>, window_with_time_or_count_invalid<AN...>>;
 };
 template<class... AN>
-using window_with_time_or_count_tag_invalid_t = typename window_with_time_or_count_tag_invalid<AN...>::type;
+using window_with_time_or_count_invalid_t = typename window_with_time_or_count_invalid<AN...>::type;
 
 template<class T, class Duration, class Coordination>
 struct window_with_time_or_count
@@ -269,7 +269,7 @@ struct member_overload<window_with_time_or_count_tag>
     }
 
     template<class... AN>
-    static operators::detail::window_with_time_or_count_tag_invalid_t<AN...> member(AN...) {
+    static operators::detail::window_with_time_or_count_invalid_t<AN...> member(AN...) {
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "window_with_time_or_count takes (Duration, Count, optional Coordination)");

--- a/Rx/v2/src/rxcpp/operators/rx-window_time_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_time_count.hpp
@@ -2,6 +2,28 @@
 
 #pragma once
 
+/*! \file rx-window_time_count.hpp
+
+    \brief Return an observable that emits connected, non-overlapping windows of items from the source observable that were emitted during a fixed duration of time or when the window has reached maximum capacity (whichever occurs first), on the specified scheduler.
+
+    \tparam Duration      the type of time intervals.
+    \tparam Coordination  the type of the scheduler (optional).
+
+    \param period        the period of time each window collects items before it is completed and replaced with a new window.
+    \param count         the maximum size of each window before it is completed and new window is created.
+    \param coordination  the scheduler for the windows (optional).
+
+    \return  Observable that emits connected, non-overlapping windows of items from the source observable that were emitted during a fixed duration of time or when the window has reached maximum capacity (whichever occurs first).
+
+    \sample
+    \snippet window.cpp window period+count+coordination sample
+    \snippet output.txt window period+count+coordination sample
+
+    \sample
+    \snippet window.cpp window period+count sample
+    \snippet output.txt window period+count sample
+*/
+
 #if !defined(RXCPP_OPERATORS_RX_WINDOW_WITH_TIME_OR_COUNT_HPP)
 #define RXCPP_OPERATORS_RX_WINDOW_WITH_TIME_OR_COUNT_HPP
 
@@ -13,10 +35,21 @@ namespace operators {
 
 namespace detail {
 
+template<class... AN>
+struct window_with_time_or_count_tag_invalid_arguments {};
+
+template<class... AN>
+struct window_with_time_or_count_tag_invalid : public rxo::operator_base<window_with_time_or_count_tag_invalid_arguments<AN...>> {
+    using type = observable<window_with_time_or_count_tag_invalid_arguments<AN...>, window_with_time_or_count_tag_invalid<AN...>>;
+};
+template<class... AN>
+using window_with_time_or_count_tag_invalid_t = typename window_with_time_or_count_tag_invalid<AN...>::type;
+
 template<class T, class Duration, class Coordination>
 struct window_with_time_or_count
 {
     typedef rxu::decay_t<T> source_value_type;
+    typedef observable<source_value_type> value_type;
     typedef rxu::decay_t<Coordination> coordination_type;
     typedef typename coordination_type::coordinator_type coordinator_type;
     typedef rxu::decay_t<Duration> duration_type;
@@ -195,33 +228,53 @@ struct window_with_time_or_count
     }
 };
 
-template<class Duration, class Coordination>
-class window_with_time_or_count_factory
-{
-    typedef rxu::decay_t<Duration> duration_type;
-    typedef rxu::decay_t<Coordination> coordination_type;
+}
 
-    duration_type period;
-    int count;
-    coordination_type coordination;
-public:
-    window_with_time_or_count_factory(duration_type p, int n, coordination_type c) : period(p), count(n), coordination(c) {}
-    template<class Observable>
-    auto operator()(Observable&& source)
-        -> decltype(source.template lift<observable<rxu::value_type_t<rxu::decay_t<Observable>>>>(window_with_time_or_count<rxu::value_type_t<rxu::decay_t<Observable>>, Duration, Coordination>(period, count, coordination))) {
-        return      source.template lift<observable<rxu::value_type_t<rxu::decay_t<Observable>>>>(window_with_time_or_count<rxu::value_type_t<rxu::decay_t<Observable>>, Duration, Coordination>(period, count, coordination));
+/*! @copydoc rx-window_time_count.hpp
+*/
+template<class... AN>
+auto window_with_time_or_count(AN&&... an)
+    ->      operator_factory<window_with_time_or_count_tag, AN...> {
+     return operator_factory<window_with_time_or_count_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
+}
+
+}
+
+template<>
+struct member_overload<window_with_time_or_count_tag>
+{
+    template<class Observable, class Duration,
+        class Enabled = rxu::enable_if_all_true_type_t<
+            is_observable<Observable>,
+            std::is_convertible<Duration, rxsc::scheduler::clock_type::duration>>,
+        class SourceValue = rxu::value_type_t<Observable>,
+        class WindowTimeCount = rxo::detail::window_with_time_or_count<SourceValue, rxu::decay_t<Duration>, identity_one_worker>,
+        class Value = rxu::value_type_t<WindowTimeCount>>
+    static auto member(Observable&& o, Duration&& period, int count)
+        -> decltype(o.template lift<Value>(WindowTimeCount(std::forward<Duration>(period), count, identity_current_thread()))) {
+        return      o.template lift<Value>(WindowTimeCount(std::forward<Duration>(period), count, identity_current_thread()));
+    }
+
+    template<class Observable, class Duration, class Coordination,
+        class Enabled = rxu::enable_if_all_true_type_t<
+            is_observable<Observable>,
+            std::is_convertible<Duration, rxsc::scheduler::clock_type::duration>,
+            is_coordination<Coordination>>,
+        class SourceValue = rxu::value_type_t<Observable>,
+        class WindowTimeCount = rxo::detail::window_with_time_or_count<SourceValue, rxu::decay_t<Duration>, rxu::decay_t<Coordination>>,
+        class Value = rxu::value_type_t<WindowTimeCount>>
+    static auto member(Observable&& o, Duration&& period, int count, Coordination&& cn)
+        -> decltype(o.template lift<Value>(WindowTimeCount(std::forward<Duration>(period), count, std::forward<Coordination>(cn)))) {
+        return      o.template lift<Value>(WindowTimeCount(std::forward<Duration>(period), count, std::forward<Coordination>(cn)));
+    }
+
+    template<class... AN>
+    static operators::detail::window_with_time_or_count_tag_invalid_t<AN...> member(AN...) {
+        std::terminate();
+        return {};
+        static_assert(sizeof...(AN) == 10000, "window_with_time_or_count takes (Duration, Count, optional Coordination)");
     }
 };
-
-}
-
-template<class Duration, class Coordination>
-inline auto window_with_time_or_count(Duration period, int count, Coordination coordination)
-    ->      detail::window_with_time_or_count_factory<Duration, Coordination> {
-    return  detail::window_with_time_or_count_factory<Duration, Coordination>(period, count, coordination);
-}
-
-}
 
 }
 

--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -213,6 +213,7 @@
 #include "operators/rx-timestamp.hpp"
 #include "operators/rx-window.hpp"
 #include "operators/rx-window_time.hpp"
+#include "operators/rx-window_time_count.hpp"
 #include "operators/rx-with_latest_from.hpp"
 #include "operators/rx-zip.hpp"
 #endif

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -1019,50 +1019,15 @@ public:
         return  observable_member(window_with_time_tag{},                *this, std::forward<AN>(an)...);
     }
 
-    /*! Return an observable that emits connected, non-overlapping windows of items from the source observable that were emitted during a fixed duration of time or when the window has reached maximum capacity (whichever occurs first), on the specified scheduler.
-
-        \tparam Duration      the type of time intervals
-        \tparam Coordination  the type of the scheduler
-
-        \param period        the period of time each window collects items before it is completed and replaced with a new window
-        \param count         the maximum size of each window before it is completed and new window is created
-        \param coordination  the scheduler for the windows
-
-        \return  Observable that emits connected, non-overlapping windows of items from the source observable that were emitted during a fixed duration of time or when the window has reached maximum capacity (whichever occurs first).
-
-        \sample
-        \snippet window.cpp window period+count+coordination sample
-        \snippet output.txt window period+count+coordination sample
+    /*! @copydoc rx-window_time_count.hpp
     */
-    template<class Duration, class Coordination>
-    auto window_with_time_or_count(Duration period, int count, Coordination coordination) const
-        /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(EXPLICIT_THIS lift<observable<T>>(rxo::detail::window_with_time_or_count<T, Duration, Coordination>(period, count, coordination)))
-        /// \endcond
+    template<class... AN>
+    auto window_with_time_or_count(AN&&... an) const
+    /// \cond SHOW_SERVICE_MEMBERS
+    -> decltype(observable_member(window_with_time_or_count_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    /// \endcond
     {
-        return                    lift<observable<T>>(rxo::detail::window_with_time_or_count<T, Duration, Coordination>(period, count, coordination));
-    }
-
-    /*! Return an observable that emits connected, non-overlapping windows of items from the source observable that were emitted during a fixed duration of time or when the window has reached maximum capacity (whichever occurs first).
-
-        \tparam Duration  the type of time intervals
-
-        \param period  the period of time each window collects items before it is completed and replaced with a new window
-        \param count   the maximum size of each window before it is completed and new window is created
-
-        \return  Observable that emits connected, non-overlapping windows of items from the source observable that were emitted during a fixed duration of time or when the window has reached maximum capacity (whichever occurs first).
-
-        \sample
-        \snippet window.cpp window period+count sample
-        \snippet output.txt window period+count sample
-    */
-    template<class Duration>
-    auto window_with_time_or_count(Duration period, int count) const
-        /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(EXPLICIT_THIS lift<observable<T>>(rxo::detail::window_with_time_or_count<T, Duration, identity_one_worker>(period, count, identity_current_thread())))
-        /// \endcond
-    {
-        return                    lift<observable<T>>(rxo::detail::window_with_time_or_count<T, Duration, identity_one_worker>(period, count, identity_current_thread()));
+        return  observable_member(window_with_time_or_count_tag{},                *this, std::forward<AN>(an)...);
     }
 
     /*! Return an observable that emits observables every period time interval and collects items from this observable for period of time into each produced observable, on the specified scheduler.
@@ -1135,7 +1100,7 @@ public:
         return  observable_member(buffer_with_time_tag{},                *this, std::forward<AN>(an)...);
     }
 
-    /*! @copydoc rx-buffer_time.hpp
+    /*! @copydoc rx-buffer_time_count.hpp
      */
     template<class... AN>
     auto buffer_with_time_or_count(AN&&... an) const
@@ -3095,7 +3060,7 @@ public:
 //
 // support range() >> filter() >> subscribe() syntax
 // '>>' is spelled 'stream'
-//K
+//
 template<class T, class SourceOperator, class OperatorFactory>
 auto operator >> (const rxcpp::observable<T, SourceOperator>& source, OperatorFactory&& of)
     -> decltype(source.op(std::forward<OperatorFactory>(of))) {

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -118,7 +118,6 @@ public:
 #include "operators/rx-take_last.hpp"
 #include "operators/rx-take_until.hpp"
 #include "operators/rx-tap.hpp"
-#include "operators/rx-window_time_count.hpp"
 #include "operators/rx-window_toggle.hpp"
 
 namespace rxcpp {
@@ -357,7 +356,14 @@ struct window_with_time_tag {
         static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-window_time.hpp>");
     };
 };
-    
+
+ struct window_with_time_or_count_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-window_time_count.hpp>");
+    };
+};
+
 struct with_latest_from_tag {
     template<class Included>
     struct include_header{

--- a/Rx/v2/test/operators/window.cpp
+++ b/Rx/v2/test/operators/window.cpp
@@ -3,6 +3,7 @@
 #include <rxcpp/operators/rx-map.hpp>
 #include <rxcpp/operators/rx-window.hpp>
 #include <rxcpp/operators/rx-window_time.hpp>
+#include <rxcpp/operators/rx-window_time_count.hpp>
 
 SCENARIO("window count, basic", "[window][operators]"){
     GIVEN("1 hot observable of ints."){
@@ -771,10 +772,10 @@ SCENARIO("window with time or count, basic", "[window_with_time_or_count][operat
             auto res = w.start(
                 [&]() {
                     return xs
-                        .window_with_time_or_count(milliseconds(70), 3, so)
-                        .merge()
+                        | rxo::window_with_time_or_count(milliseconds(70), 3, so)
+                        | rxo::merge()
                         // forget type to workaround lambda deduction bug on msvc 2013
-                        .as_dynamic();
+                        | rxo::as_dynamic();
                 }
             );
 


### PR DESCRIPTION
Decoupled `window_with_time_or_count` from observable, fixed a couple of typos.
Please review.

Thank you,
Grigoriy
