### PR TITLE
decouple skip_until from observable

### DIFF
--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -209,6 +209,7 @@
 #include "operators/rx-sequence_equal.hpp"
 #include "operators/rx-skip.hpp"
 #include "operators/rx-skip_last.hpp"
+#include "operators/rx-skip_until.hpp"
 #include "operators/rx-take.hpp"
 #include "operators/rx-take_last.hpp"
 #include "operators/rx-take_until.hpp"

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -2004,7 +2004,7 @@ public:
         return      observable_member(skip_tag{},                *this, std::forward<AN>(an)...);
     }
 
-     /*! @copydoc rx-skip_last.hpp
+    /*! @copydoc rx-skip_last.hpp
     */
     template<class... AN>
     auto skip_last(AN... an) const
@@ -2015,54 +2015,15 @@ public:
         return      observable_member(skip_last_tag{},                *this, std::forward<AN>(an)...);
     }
 
-    /*! Make new observable with items skipped until on_next occurs on the trigger observable
-
-        \tparam  TriggerSource  the type of the trigger observable
-
-        \param  t  an observable that has to emit an item before the source observable's elements begin to be mirrored by the resulting observable
-
-        \return  An observable that skips items from the source observable until the second observable emits an item, then emits the remaining items.
-
-        \note All sources must be synchronized! This means that calls across all the subscribers must be serial.
-
-        \sample
-        \snippet skip_until.cpp skip_until sample
-        \snippet output.txt skip_until sample
+    /*! @copydoc rx-skip_until.hpp
     */
-    template<class TriggerSource>
-    auto skip_until(TriggerSource&& t) const
+    template<class... AN>
+    auto skip_until(AN... an) const
         /// \cond SHOW_SERVICE_MEMBERS
-        -> typename std::enable_if<is_observable<TriggerSource>::value,
-                observable<T,   rxo::detail::skip_until<T, this_type, TriggerSource, identity_one_worker>>>::type
+        -> decltype(observable_member(skip_until_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
         /// \endcond
     {
-        return  observable<T,   rxo::detail::skip_until<T, this_type, TriggerSource, identity_one_worker>>(
-                                rxo::detail::skip_until<T, this_type, TriggerSource, identity_one_worker>(*this, std::forward<TriggerSource>(t), identity_one_worker(rxsc::make_current_thread())));
-    }
-
-    /*! Make new observable with items skipped until on_next occurs on the trigger observable
-
-        \tparam  TriggerSource  the type of the trigger observable
-        \tparam  Coordination   the type of the scheduler
-
-        \param  t   an observable that has to emit an item before the source observable's elements begin to be mirrored by the resulting observable
-        \param  cn  the scheduler to use for scheduling the items
-
-        \return  An observable that skips items from the source observable until the second observable emits an item, then emits the remaining items.
-
-        \sample
-        \snippet skip_until.cpp threaded skip_until sample
-        \snippet output.txt threaded skip_until sample
-    */
-    template<class TriggerSource, class Coordination>
-    auto skip_until(TriggerSource&& t, Coordination&& cn) const
-        /// \cond SHOW_SERVICE_MEMBERS
-        -> typename std::enable_if<is_observable<TriggerSource>::value && is_coordination<Coordination>::value,
-                observable<T,   rxo::detail::skip_until<T, this_type, TriggerSource, Coordination>>>::type
-        /// \endcond
-    {
-        return  observable<T,   rxo::detail::skip_until<T, this_type, TriggerSource, Coordination>>(
-                                rxo::detail::skip_until<T, this_type, TriggerSource, Coordination>(*this, std::forward<TriggerSource>(t), std::forward<Coordination>(cn)));
+        return      observable_member(skip_until_tag{},                *this, std::forward<AN>(an)...);
     }
 
     /*! @copydoc rx-take.hpp

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -106,7 +106,6 @@ public:
 #include "operators/rx-ref_count.hpp"
 #include "operators/rx-replay.hpp"
 #include "operators/rx-scan.hpp"
-#include "operators/rx-skip_until.hpp"
 #include "operators/rx-start_with.hpp"
 #include "operators/rx-subscribe.hpp"
 #include "operators/rx-subscribe_on.hpp"
@@ -321,6 +320,13 @@ struct skip_last_tag {
     template<class Included>
     struct include_header{
         static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-skip_last.hpp>");
+    };
+};
+
+struct skip_until_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-skip_until.hpp>");
     };
 };
 

--- a/Rx/v2/test/operators/skip_until.cpp
+++ b/Rx/v2/test/operators/skip_until.cpp
@@ -1,4 +1,5 @@
 #include "../test.h"
+#include <rxcpp/operators/rx-skip_until.hpp>
 
 SCENARIO("skip_until, some data next", "[skip_until][skip][operators]"){
     GIVEN("2 sources"){
@@ -26,9 +27,9 @@ SCENARIO("skip_until, some data next", "[skip_until][skip][operators]"){
             auto res = w.start(
                 [&]() {
                     return l
-                        .skip_until(r)
+                        | rxo::skip_until(r)
                         // forget type to workaround lambda deduction bug on msvc 2013
-                        .as_dynamic();
+                        | rxo::as_dynamic();
                 }
             );
 
@@ -552,6 +553,58 @@ SCENARIO("skip_until, never never", "[skip_until][skip][operators]"){
                     on.subscribe(200, 1000)
                 });
                 auto actual = r.subscriptions();
+                REQUIRE(required == actual);
+            }
+        }
+    }
+}
+
+SCENARIO("skip_until time point, some data next", "[skip_until][skip][operators]"){
+    GIVEN("2 sources"){
+        using clock_type = rxsc::detail::test_type::clock_type;
+
+        auto sc = rxsc::make_test();
+        auto so = rx::synchronize_in_one_worker(sc);
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        auto l = sc.make_hot_observable({
+            on.next(150, 1),
+            on.next(210, 2),
+            on.next(220, 3),
+            on.next(230, 4),
+            on.next(240, 5),
+            on.completed(250)
+        });
+
+        clock_type::time_point t(std::chrono::milliseconds(225));
+
+        WHEN("invoked with a time point"){
+
+            auto res = w.start(
+                [&]() {
+                    return l
+                        | rxo::skip_until(t, so)
+                        // forget type to workaround lambda deduction bug on msvc 2013
+                        | rxo::as_dynamic();
+                }
+            );
+
+            THEN("the output only contains items sent while subscribed"){
+                auto required = rxu::to_vector({
+                    on.next(231, 4),
+                    on.next(241, 5),
+                    on.completed(251)
+                });
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+            THEN("there was 1 subscription/unsubscription to the source"){
+                auto required = rxu::to_vector({
+                    on.subscribe(200, 250)
+                });
+                auto actual = l.subscriptions();
                 REQUIRE(required == actual);
             }
         }


### PR DESCRIPTION
Decoupled `skip_until` from observable.
To make it similar to `take_until`, added a version of skip_until with a time point.
Please review.

Thank you,
Grigoriy
