### PR TITLE
exposed to_time_point on the test scheduler

### DIFF
--- a/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
@@ -141,6 +141,10 @@ public:
         return state->clock();
     }
 
+    clock_type::time_point to_time_point(long absolute) const {
+        return state->to_time_point(absolute);
+    }
+
     std::shared_ptr<test_type_worker> create_test_type_worker_interface() const {
         return std::make_shared<test_type_worker>(state);
     }
@@ -555,6 +559,10 @@ public:
 
     bool is_enabled() const {return tester->is_enabled();}
     long clock() const {return tester->clock();}
+
+    clock_type::time_point to_time_point(long absolute) const {
+        return tester->to_time_point(absolute);
+    }
 
     template<class T>
     rxt::testable_observable<T> make_hot_observable(std::vector<rxn::recorded<std::shared_ptr<rxn::detail::notification_base<T>>>> messages) const{

--- a/Rx/v2/test/operators/skip_until.cpp
+++ b/Rx/v2/test/operators/skip_until.cpp
@@ -561,8 +561,6 @@ SCENARIO("skip_until, never never", "[skip_until][skip][operators]"){
 
 SCENARIO("skip_until time point, some data next", "[skip_until][skip][operators]"){
     GIVEN("2 sources"){
-        using clock_type = rxsc::detail::test_type::clock_type;
-
         auto sc = rxsc::make_test();
         auto so = rx::synchronize_in_one_worker(sc);
         auto w = sc.create_worker();
@@ -577,7 +575,7 @@ SCENARIO("skip_until time point, some data next", "[skip_until][skip][operators]
             on.completed(250)
         });
 
-        clock_type::time_point t(std::chrono::milliseconds(225));
+        auto t = sc.to_time_point(225);
 
         WHEN("invoked with a time point"){
 

--- a/Rx/v2/test/operators/take_until.cpp
+++ b/Rx/v2/test/operators/take_until.cpp
@@ -745,8 +745,6 @@ SCENARIO("take_until, error some", "[take_until][take][operators]"){
 
 SCENARIO("take_until trigger on time point", "[take_until][take][operators]"){
     GIVEN("a source and a time point"){
-        using clock_type = rxsc::detail::test_type::clock_type;
-
         auto sc = rxsc::make_test();
         auto so = rx::synchronize_in_one_worker(sc);
         auto w = sc.create_worker();
@@ -761,7 +759,7 @@ SCENARIO("take_until trigger on time point", "[take_until][take][operators]"){
             on.completed(250)
         });
 
-        clock_type::time_point t(std::chrono::milliseconds(225));
+        auto t = sc.to_time_point(225);
 
         WHEN("invoked with a time point"){
 


### PR DESCRIPTION
Exposed `to_time_point` on the test scheduler, updated `skip_until` and `take_until` tests,
please review.

Thank you,
Grigoriy
