### PR TITLE
decouple window_toggle from observable

### DIFF
--- a/Rx/v2/src/rxcpp/rx-includes.hpp
+++ b/Rx/v2/src/rxcpp/rx-includes.hpp
@@ -220,6 +220,7 @@
 #include "operators/rx-window.hpp"
 #include "operators/rx-window_time.hpp"
 #include "operators/rx-window_time_count.hpp"
+#include "operators/rx-window_toggle.hpp"
 #include "operators/rx-with_latest_from.hpp"
 #include "operators/rx-zip.hpp"
 #endif

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -1030,52 +1030,15 @@ public:
         return  observable_member(window_with_time_or_count_tag{},                *this, std::forward<AN>(an)...);
     }
 
-    /*! Return an observable that emits observables every period time interval and collects items from this observable for period of time into each produced observable, on the specified scheduler.
-
-        \tparam Openings        observable<OT>
-        \tparam ClosingSelector a function of type observable<CT>(OT)
-        \tparam Coordination    the type of the scheduler
-
-        \param opens         each value from this observable opens a new window.
-        \param closes        this function is called for each opened window and returns an observable. the first value from the returned observable will close the window
-        \param coordination  the scheduler for the windows
-
-        \return  Observable that emits an observable for each opened window.
-
-        \sample
-        \snippet window.cpp window toggle+coordination sample
-        \snippet output.txt window toggle+coordination sample
+    /*! @copydoc rx-window_toggle.hpp
     */
-    template<class Openings, class ClosingSelector, class Coordination, class Reqiures = typename rxu::types_checked_from<typename Coordination::coordination_tag>::type>
-    auto window_toggle(Openings opens, ClosingSelector closes, Coordination coordination) const
-        /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(EXPLICIT_THIS lift<observable<T>>(rxo::detail::window_toggle<T, Openings, ClosingSelector, Coordination>(opens, closes, coordination)))
-        /// \endcond
+    template<class... AN>
+    auto window_toggle(AN&&... an) const
+    /// \cond SHOW_SERVICE_MEMBERS
+    -> decltype(observable_member(window_toggle_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    /// \endcond
     {
-        return                    lift<observable<T>>(rxo::detail::window_toggle<T, Openings, ClosingSelector, Coordination>(opens, closes, coordination));
-    }
-
-    /*! Return an observable that emits connected, non-overlapping windows represending items emitted by the source observable during fixed, consecutive durations.
-
-        \tparam Openings        observable<OT>
-        \tparam ClosingSelector a function of type observable<CT>(OT)
-
-        \param opens         each value from this observable opens a new window.
-        \param closes        this function is called for each opened window and returns an observable. the first value from the returned observable will close the window
-
-        \return  Observable that emits an observable for each opened window.
-
-        \sample
-        \snippet window.cpp window toggle sample
-        \snippet output.txt window toggle sample
-    */
-    template<class Openings, class ClosingSelector>
-    auto window_toggle(Openings opens, ClosingSelector closes) const
-        /// \cond SHOW_SERVICE_MEMBERS
-        -> decltype(EXPLICIT_THIS lift<observable<T>>(rxo::detail::window_toggle<T, Openings, ClosingSelector, identity_one_worker>(opens, closes, identity_current_thread())))
-        /// \endcond
-    {
-        return                    lift<observable<T>>(rxo::detail::window_toggle<T, Openings, ClosingSelector, identity_one_worker>(opens, closes, identity_current_thread()));
+        return  observable_member(window_toggle_tag{},                *this, std::forward<AN>(an)...);
     }
 
     /*! @copydoc rx-buffer_count.hpp

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -112,7 +112,6 @@ public:
 #include "operators/rx-switch_if_empty.hpp"
 #include "operators/rx-switch_on_next.hpp"
 #include "operators/rx-tap.hpp"
-#include "operators/rx-window_toggle.hpp"
 
 namespace rxcpp {
 
@@ -393,10 +392,17 @@ struct window_with_time_tag {
     };
 };
 
- struct window_with_time_or_count_tag {
+struct window_with_time_or_count_tag {
     template<class Included>
     struct include_header{
         static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-window_time_count.hpp>");
+    };
+};
+
+struct window_toggle_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-window_toggle.hpp>");
     };
 };
 

--- a/Rx/v2/test/operators/window_toggle.cpp
+++ b/Rx/v2/test/operators/window_toggle.cpp
@@ -1,6 +1,7 @@
 #include "../test.h"
 #include <rxcpp/operators/rx-map.hpp>
 #include <rxcpp/operators/rx-merge.hpp>
+#include <rxcpp/operators/rx-window_toggle.hpp>
 
 SCENARIO("window toggle, basic", "[window_toggle][operators]"){
     GIVEN("1 hot observable of ints and hot observable of opens."){
@@ -40,19 +41,19 @@ SCENARIO("window toggle, basic", "[window_toggle][operators]"){
             auto res = w.start(
                 [&]() {
                     return xs
-                        .window_toggle(ys, [&](int y){
+                        | rxo::window_toggle(ys, [&](int y){
                             return rx::observable<>::timer(milliseconds(y), so);
                         }, so)
-                        .map([wi](rxcpp::observable<int> w) mutable {
+                        | rxo::map([wi](rxcpp::observable<int> w) mutable {
                             auto ti = wi++;
                             return w
-                                .map([ti](int x){return std::to_string(ti) + " " + std::to_string(x);})
+                                | rxo::map([ti](int x){return std::to_string(ti) + " " + std::to_string(x);})
                                 // forget type to workaround lambda deduction bug on msvc 2013
-                                .as_dynamic();
+                                | rxo::as_dynamic();
                         })
-                        .merge()
+                        | rxo::merge()
                         // forget type to workaround lambda deduction bug on msvc 2013
-                        .as_dynamic();
+                        | rxo::as_dynamic();
                 }
             );
 
@@ -114,7 +115,7 @@ SCENARIO("window toggle, basic same", "[window_toggle][operators]"){
 
         WHEN("ints are split into windows"){
             using namespace std::chrono;
-            
+
             int wi = 0;
 
             auto res = w.start(
@@ -273,7 +274,7 @@ SCENARIO("window toggle, disposed", "[window_toggle][operators]"){
 
         WHEN("ints are split into windows"){
             using namespace std::chrono;
-            
+
             int wi = 0;
 
             auto res = w.start(


### PR DESCRIPTION
Decoupled `window_toggle` from observable,
please review.

When decoupling, I removed traits and used `result_of` on ClosingSelector [here](https://github.com/Reactive-Extensions/RxCpp/compare/master...gchudnov:window_toggle-o2?expand=1#diff-7ab818a409f457349089e6f33a31e15bR60) are [here](https://github.com/Reactive-Extensions/RxCpp/compare/master...gchudnov:window_toggle-o2?expand=1#diff-7ab818a409f457349089e6f33a31e15bR302). If that's not ok, let me know.

Thank you,
Grigoriy
