### PR TITLE
decouple ref_count from connectable_observable

### DIFF
--- a/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
@@ -162,16 +162,15 @@ public:
         return cs;
     }
 
-    /// ref_count ->
-    /// takes a connectable_observable source and uses a ref_count of the subscribers
-    /// to control the connection to the published source. The first subscription
-    /// will cause a call to connect() and the last unsubscribe will unsubscribe the
-    /// connection.
-    ///
-    auto ref_count() const
-        ->      observable<T,   rxo::detail::ref_count<T, this_type>> {
-        return  observable<T,   rxo::detail::ref_count<T, this_type>>(
-                                rxo::detail::ref_count<T, this_type>(*this));
+    /*! @copydoc rx-ref_count.hpp
+     */
+    template<class... AN>
+    auto ref_count(AN... an) const
+        /// \cond SHOW_SERVICE_MEMBERS
+        -> decltype(observable_member(ref_count_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        /// \endcond
+    {
+        return      observable_member(ref_count_tag{},                *this, std::forward<AN>(an)...);
     }
 
     /*! @copydoc rx-connect_forever.hpp

--- a/Rx/v2/src/rxcpp/rx-operators.hpp
+++ b/Rx/v2/src/rxcpp/rx-operators.hpp
@@ -96,7 +96,6 @@ public:
 }
 
 #include "operators/rx-lift.hpp"
-#include "operators/rx-ref_count.hpp"
 #include "operators/rx-subscribe.hpp"
 
 namespace rxcpp {
@@ -300,6 +299,13 @@ struct sum_tag : reduce_tag {};
 struct average_tag : reduce_tag {};
 struct min_tag : reduce_tag {};
 struct max_tag : reduce_tag {};
+
+struct ref_count_tag {
+    template<class Included>
+    struct include_header{
+        static_assert(Included::value, "missing include: please #include <rxcpp/operators/rx-ref_count.hpp>");
+    };
+};
 
 struct pairwise_tag {
     template<class Included>
@@ -510,5 +516,6 @@ struct zip_tag {
 
 #include "operators/rx-multicast.hpp"
 #include "operators/rx-publish.hpp"
+#include "operators/rx-ref_count.hpp"
 
 #endif

--- a/Rx/v2/test/operators/publish.cpp
+++ b/Rx/v2/test/operators/publish.cpp
@@ -1,6 +1,8 @@
 #include "../test.h"
 #include <rxcpp/operators/rx-publish.hpp>
 #include <rxcpp/operators/rx-connect_forever.hpp>
+#include <rxcpp/operators/rx-ref_count.hpp>
+
 
 SCENARIO("publish range", "[hide][range][subject][publish][subject][operators]"){
     GIVEN("a range"){

--- a/Rx/v2/test/subscriptions/subscription.cpp
+++ b/Rx/v2/test/subscriptions/subscription.cpp
@@ -4,6 +4,7 @@
 #include "rxcpp/operators/rx-take.hpp"
 #include "rxcpp/operators/rx-observe_on.hpp"
 #include "rxcpp/operators/rx-publish.hpp"
+#include "rxcpp/operators/rx-ref_count.hpp"
 
 SCENARIO("observe subscription", "[hide]"){
     GIVEN("observable of ints"){


### PR DESCRIPTION
Decoupled `ref_count` from `connectable_observable`
Put the include to the bottom of `rx-operators.hpp` as there is a dependency in [rx-synchronize](https://github.com/Reactive-Extensions/RxCpp/blob/master/Rx/v2/src/rxcpp/subjects/rx-synchronize.hpp#L220)

Please review

Thank you,
Grigoriy