### PR TITLE
add aliases and fix docs

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
@@ -279,6 +279,14 @@ auto concat_map(AN&&... an)
     return operator_factory<concat_map_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
 }
 
+/*! @copydoc rx-concat_map.hpp
+*/
+template<class... AN>
+auto concat_transform(AN&&... an)
+->     operator_factory<concat_map_tag, AN...> {
+    return operator_factory<concat_map_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
+}
+
 }
 
 template<>

--- a/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
@@ -246,6 +246,14 @@ auto flat_map(AN&&... an)
     return operator_factory<flat_map_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
 }
 
+/*! @copydoc rx-flat_map.hpp
+*/
+template<class... AN>
+auto merge_transform(AN&&... an)
+->     operator_factory<flat_map_tag, AN...> {
+    return operator_factory<flat_map_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
+}
+
 }
 
 template<>

--- a/Rx/v2/src/rxcpp/operators/rx-map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-map.hpp
@@ -37,7 +37,7 @@ struct map_invalid : public rxo::operator_base<map_invalid_arguments<AN...>> {
 };
 template<class... AN>
 using map_invalid_t = typename map_invalid<AN...>::type;
-    
+
 template<class T, class Selector>
 struct map
 {
@@ -107,6 +107,14 @@ auto map(AN&&... an)
     return operator_factory<map_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
 }
 
+/*! @copydoc rx-map.hpp
+*/
+template<class... AN>
+auto transform(AN&&... an)
+    -> operator_factory<map_tag, AN...> {
+    return operator_factory<map_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
+}
+
 }
 
 template<>
@@ -131,7 +139,7 @@ struct member_overload<map_tag>
         static_assert(sizeof...(AN) == 10000, "map takes Selector");
     }
 };
-    
+
 }
 
 #endif

--- a/Rx/v2/src/rxcpp/operators/rx-on_error_resume_next.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-on_error_resume_next.hpp
@@ -112,6 +112,14 @@ auto on_error_resume_next(AN&&... an)
     return operator_factory<on_error_resume_next_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
 }
 
+/*! @copydoc rx-on_error_resume_next.hpp
+*/
+template<class... AN>
+auto switch_on_error(AN&&... an)
+    ->     operator_factory<on_error_resume_next_tag, AN...> {
+    return operator_factory<on_error_resume_next_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
+}
+
 }
 
 template<>

--- a/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
@@ -350,7 +350,15 @@ struct last {
 /*! @copydoc rx-reduce.hpp
 */
 template<class... AN>
-auto reduce(AN&&... an) 
+auto reduce(AN&&... an)
+    ->     operator_factory<reduce_tag, AN...> {
+    return operator_factory<reduce_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
+}
+
+/*! @copydoc rx-reduce.hpp
+*/
+template<class... AN>
+auto accumulate(AN&&... an)
     ->     operator_factory<reduce_tag, AN...> {
     return operator_factory<reduce_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
 }
@@ -367,7 +375,7 @@ auto reduce(AN&&... an)
     \snippet math.cpp first empty sample
     \snippet output.txt first empty sample
 */
-inline auto first() 
+inline auto first()
     ->     operator_factory<first_tag> {
     return operator_factory<first_tag>(std::tuple<>{});
 }
@@ -384,7 +392,7 @@ inline auto first()
     \snippet math.cpp last empty sample
     \snippet output.txt last empty sample
 */
-inline auto last() 
+inline auto last()
     ->     operator_factory<last_tag> {
     return operator_factory<last_tag>(std::tuple<>{});
 }
@@ -492,11 +500,11 @@ inline auto max()
 
 }
 
-template<> 
+template<>
 struct member_overload<reduce_tag>
 {
 
-    template<class Observable, class Seed, class Accumulator, class ResultSelector, 
+    template<class Observable, class Seed, class Accumulator, class ResultSelector,
         class Reduce = rxo::detail::reduce<rxu::value_type_t<Observable>, rxu::decay_t<Observable>, rxu::decay_t<Accumulator>, rxu::decay_t<ResultSelector>, rxu::decay_t<Seed>>,
         class Value = rxu::value_type_t<Reduce>,
         class Result = observable<Value, Reduce>>
@@ -505,8 +513,8 @@ struct member_overload<reduce_tag>
         return Result(Reduce(std::forward<Observable>(o), std::forward<Accumulator>(a), std::forward<ResultSelector>(r), std::forward<Seed>(s)));
     }
 
-    template<class Observable, class Seed, class Accumulator, 
-        class ResultSelector=rxu::detail::take_at<0>, 
+    template<class Observable, class Seed, class Accumulator,
+        class ResultSelector=rxu::detail::take_at<0>,
         class Reduce = rxo::detail::reduce<rxu::value_type_t<Observable>, rxu::decay_t<Observable>, rxu::decay_t<Accumulator>, rxu::decay_t<ResultSelector>, rxu::decay_t<Seed>>,
         class Value = rxu::value_type_t<Reduce>,
         class Result = observable<Value, Reduce>>
@@ -520,18 +528,18 @@ struct member_overload<reduce_tag>
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "reduce takes (Seed, Accumulator, optional ResultSelector), Accumulator takes (Seed, Observable::value_type) -> Seed, ResultSelector takes (Observable::value_type) -> ResultValue");
-    } 
+    }
 };
 
-template<> 
+template<>
 struct member_overload<first_tag>
 {
-    template<class Observable, 
+    template<class Observable,
         class SValue = rxu::value_type_t<Observable>,
         class Operation = operators::detail::first<SValue>,
-        class Seed = decltype(Operation::seed()), 
-        class Accumulator = Operation, 
-        class ResultSelector = Operation, 
+        class Seed = decltype(Operation::seed()),
+        class Accumulator = Operation,
+        class ResultSelector = Operation,
         class TakeOne = decltype(((rxu::decay_t<Observable>*)nullptr)->take(1)),
         class Reduce = rxo::detail::reduce<SValue, rxu::decay_t<TakeOne>, rxu::decay_t<Accumulator>, rxu::decay_t<ResultSelector>, rxu::decay_t<Seed>>,
         class RValue = rxu::value_type_t<Reduce>,
@@ -546,18 +554,18 @@ struct member_overload<first_tag>
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "first does not support Observable::value_type");
-    } 
+    }
 };
 
-template<> 
+template<>
 struct member_overload<last_tag>
 {
-    template<class Observable, 
+    template<class Observable,
         class SValue = rxu::value_type_t<Observable>,
         class Operation = operators::detail::last<SValue>,
-        class Seed = decltype(Operation::seed()), 
-        class Accumulator = Operation, 
-        class ResultSelector = Operation, 
+        class Seed = decltype(Operation::seed()),
+        class Accumulator = Operation,
+        class ResultSelector = Operation,
         class Reduce = rxo::detail::reduce<SValue, rxu::decay_t<Observable>, rxu::decay_t<Accumulator>, rxu::decay_t<ResultSelector>, rxu::decay_t<Seed>>,
         class RValue = rxu::value_type_t<Reduce>,
         class Result = observable<RValue, Reduce>>
@@ -571,18 +579,18 @@ struct member_overload<last_tag>
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "last does not support Observable::value_type");
-    } 
+    }
 };
 
-template<> 
+template<>
 struct member_overload<sum_tag>
 {
-    template<class Observable, 
+    template<class Observable,
         class SValue = rxu::value_type_t<Observable>,
         class Operation = operators::detail::sum<SValue>,
-        class Seed = decltype(Operation::seed()), 
-        class Accumulator = Operation, 
-        class ResultSelector = Operation, 
+        class Seed = decltype(Operation::seed()),
+        class Accumulator = Operation,
+        class ResultSelector = Operation,
         class Reduce = rxo::detail::reduce<SValue, rxu::decay_t<Observable>, rxu::decay_t<Accumulator>, rxu::decay_t<ResultSelector>, rxu::decay_t<Seed>>,
         class RValue = rxu::value_type_t<Reduce>,
         class Result = observable<RValue, Reduce>>
@@ -596,18 +604,18 @@ struct member_overload<sum_tag>
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "sum does not support Observable::value_type");
-    } 
+    }
 };
 
-template<> 
+template<>
 struct member_overload<average_tag>
 {
-    template<class Observable, 
+    template<class Observable,
         class SValue = rxu::value_type_t<Observable>,
         class Operation = operators::detail::average<SValue>,
-        class Seed = decltype(Operation::seed()), 
-        class Accumulator = Operation, 
-        class ResultSelector = Operation, 
+        class Seed = decltype(Operation::seed()),
+        class Accumulator = Operation,
+        class ResultSelector = Operation,
         class Reduce = rxo::detail::reduce<SValue, rxu::decay_t<Observable>, rxu::decay_t<Accumulator>, rxu::decay_t<ResultSelector>, rxu::decay_t<Seed>>,
         class RValue = rxu::value_type_t<Reduce>,
         class Result = observable<RValue, Reduce>>
@@ -621,18 +629,18 @@ struct member_overload<average_tag>
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "average does not support Observable::value_type");
-    } 
+    }
 };
 
-template<> 
+template<>
 struct member_overload<max_tag>
 {
-    template<class Observable, 
+    template<class Observable,
         class SValue = rxu::value_type_t<Observable>,
         class Operation = operators::detail::max<SValue>,
-        class Seed = decltype(Operation::seed()), 
-        class Accumulator = Operation, 
-        class ResultSelector = Operation, 
+        class Seed = decltype(Operation::seed()),
+        class Accumulator = Operation,
+        class ResultSelector = Operation,
         class Reduce = rxo::detail::reduce<SValue, rxu::decay_t<Observable>, rxu::decay_t<Accumulator>, rxu::decay_t<ResultSelector>, rxu::decay_t<Seed>>,
         class RValue = rxu::value_type_t<Reduce>,
         class Result = observable<RValue, Reduce>>
@@ -646,18 +654,18 @@ struct member_overload<max_tag>
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "max does not support Observable::value_type");
-    } 
+    }
 };
 
-template<> 
+template<>
 struct member_overload<min_tag>
 {
-    template<class Observable, 
+    template<class Observable,
         class SValue = rxu::value_type_t<Observable>,
         class Operation = operators::detail::min<SValue>,
-        class Seed = decltype(Operation::seed()), 
-        class Accumulator = Operation, 
-        class ResultSelector = Operation, 
+        class Seed = decltype(Operation::seed()),
+        class Accumulator = Operation,
+        class ResultSelector = Operation,
         class Reduce = rxo::detail::reduce<SValue, rxu::decay_t<Observable>, rxu::decay_t<Accumulator>, rxu::decay_t<ResultSelector>, rxu::decay_t<Seed>>,
         class RValue = rxu::value_type_t<Reduce>,
         class Result = observable<RValue, Reduce>>
@@ -671,7 +679,7 @@ struct member_overload<min_tag>
         std::terminate();
         return {};
         static_assert(sizeof...(AN) == 10000, "min does not support Observable::value_type");
-    } 
+    }
 };
 
 }

--- a/Rx/v2/src/rxcpp/operators/rx-take_while.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take_while.hpp
@@ -94,6 +94,8 @@ struct take_while
 
 }
 
+/*! @copydoc rx-take_while.hpp
+*/
 template<class... AN>
 auto take_while(AN&&... an)
     ->      operator_factory<take_while_tag, AN...> {

--- a/Rx/v2/src/rxcpp/operators/rx-window_time.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-window_time.hpp
@@ -3,7 +3,7 @@
 #pragma once
 
 /*! \file rx-window_time.hpp
-  
+
     \brief Return an observable that emits observables every period time interval and collects items from this observable for period of time into each produced observable, on the specified scheduler.
            If the skip parameter is set, return an observable that emits observables every skip time interval and collects items from this observable for period of time into each produced observable, on the specified scheduler.
 
@@ -20,7 +20,7 @@
     \sample
     \snippet window.cpp window period+skip+coordination sample
     \snippet output.txt window period+skip+coordination sample
-    
+
     \sample
     \snippet window.cpp window period+skip sample
     \snippet output.txt window period+skip sample
@@ -54,12 +54,12 @@ struct window_with_time_invalid : public rxo::operator_base<window_with_time_inv
 };
 template<class... AN>
 using window_with_time_invalid_t = typename window_with_time_invalid<AN...>::type;
-    
+
 template<class T, class Duration, class Coordination>
 struct window_with_time
 {
     typedef rxu::decay_t<T> source_value_type;
-    typedef observable<source_value_type> value_type;    
+    typedef observable<source_value_type> value_type;
     typedef rxu::decay_t<Coordination> coordination_type;
     typedef typename coordination_type::coordinator_type coordinator_type;
     typedef rxu::decay_t<Duration> duration_type;
@@ -246,13 +246,13 @@ struct window_with_time
 
 }
 
-/*! @copydoc rx-window_with_time.hpp
+/*! @copydoc rx-window_time.hpp
 */
 template<class... AN>
 auto window_with_time(AN&&... an)
     ->      operator_factory<window_with_time_tag, AN...> {
      return operator_factory<window_with_time_tag, AN...>(std::make_tuple(std::forward<AN>(an)...));
-}    
+}
 
 }
 
@@ -315,8 +315,8 @@ struct member_overload<window_with_time_tag>
         return {};
         static_assert(sizeof...(AN) == 10000, "window_with_time takes (Duration, optional Duration, optional Coordination)");
     }
-};    
-    
+};
+
 }
 
 #endif

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -455,9 +455,9 @@ public:
 };
 
 namespace detail {
-    
+
 template<class SourceOperator, class Subscriber>
-struct safe_subscriber 
+struct safe_subscriber
 {
     safe_subscriber(SourceOperator& so, Subscriber& o) : so(std::addressof(so)), o(std::addressof(o)) {}
 
@@ -850,10 +850,32 @@ public:
         return  observable_member(on_error_resume_next_tag{},                *this, std::forward<AN>(an)...);
     }
 
+    /*! @copydoc rx-on_error_resume_next.hpp
+    */
+    template<class... AN>
+    auto switch_on_error(AN&&... an) const
+    /// \cond SHOW_SERVICE_MEMBERS
+    -> decltype(observable_member(on_error_resume_next_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    /// \endcond
+    {
+        return  observable_member(on_error_resume_next_tag{},                *this, std::forward<AN>(an)...);
+    }
+
     /*! @copydoc rx-map.hpp
      */
     template<class... AN>
     auto map(AN&&... an) const
+    /// \cond SHOW_SERVICE_MEMBERS
+    -> decltype(observable_member(map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+    /// \endcond
+    {
+        return  observable_member(map_tag{},                *this, std::forward<AN>(an)...);
+    }
+
+    /*! @copydoc rx-map.hpp
+     */
+    template<class... AN>
+    auto transform(AN&&... an) const
     /// \cond SHOW_SERVICE_MEMBERS
     -> decltype(observable_member(map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
     /// \endcond
@@ -1037,6 +1059,17 @@ public:
         return      observable_member(flat_map_tag{},                *this, std::forward<AN>(an)...);
     }
 
+    /*! @copydoc rx-flat_map.hpp
+     */
+    template<class... AN>
+    auto merge_transform(AN&&... an) const
+        /// \cond SHOW_SERVICE_MEMBERS
+        -> decltype(observable_member(flat_map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        /// \endcond
+    {
+        return      observable_member(flat_map_tag{},                *this, std::forward<AN>(an)...);
+    }
+
     /*! @copydoc rx-concat.hpp
      */
     template<class... AN>
@@ -1052,6 +1085,17 @@ public:
      */
     template<class... AN>
     auto concat_map(AN&&... an) const
+        /// \cond SHOW_SERVICE_MEMBERS
+        -> decltype(observable_member(concat_map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        /// \endcond
+    {
+        return      observable_member(concat_map_tag{},                *this, std::forward<AN>(an)...);
+    }
+
+    /*! @copydoc rx-concat_map.hpp
+     */
+    template<class... AN>
+    auto concat_transform(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
         -> decltype(observable_member(concat_map_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
         /// \endcond
@@ -1185,6 +1229,17 @@ public:
      */
     template<class... AN>
     auto reduce(AN&&... an) const
+        /// \cond SHOW_SERVICE_MEMBERS
+        -> decltype(observable_member(reduce_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
+        /// \endcond
+    {
+        return      observable_member(reduce_tag{},                *this, std::forward<AN>(an)...);
+    }
+
+    /*! @copydoc rx-reduce.hpp
+     */
+    template<class... AN>
+    auto accumulate(AN&&... an) const
         /// \cond SHOW_SERVICE_MEMBERS
         -> decltype(observable_member(reduce_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
         /// \endcond


### PR DESCRIPTION
added aliases for some operators
transform (map)
merge_transform (flat_map)
concat_transform (concat_map)
switch_on_error (on_error_resume_next)
accumulate (reduce)