### PR TITLE
Rewrite repeat operator to handle 0 case correctly and not rely on magic numbers

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -8,7 +8,7 @@
 
     \tparam Count  the type of the counter (optional).
 
-    \param t  the number of times the source observable items are repeated (optional). If not specified or 0, infinitely repeats the source observable.
+    \param t  the number of times the source observable items are repeated (optional). If not specified, infinitely repeats the source observable.
 
     \return  An observable that repeats the sequence of items emitted by the source observable for t times.
 
@@ -44,6 +44,7 @@ using repeat_invalid_t = typename repeat_invalid<AN...>::type;
 
 // Contain repeat variations in a namespace
 namespace repeat {
+  // Structure to perform general repeat operations on state
   template <class ValuesType, class Subscriber, class T>
   struct state_type : public std::enable_shared_from_this<state_type<ValuesType, Subscriber, T>>,
                       public ValuesType {
@@ -77,6 +78,7 @@ namespace repeat {
                               },
                               // on_completed
                               [state]() {
+                                // Use specialized predicate for finite/infinte case
                                 if (state->on_completed_predicate()) {
                                   state->out.on_completed();
                                 } else {
@@ -91,6 +93,7 @@ namespace repeat {
     composite_subscription::weak_subscription lifetime_token;
   };
 
+  // Finite repeat case (explicitely limited with the number of times)
   template <class T, class Observable, class Count>
   struct finite : public operator_base<T> {
     typedef rxu::decay_t<Observable> source_type;
@@ -130,6 +133,7 @@ namespace repeat {
     values initial_;
   };
 
+  // Infinite repeat case
   template <class T, class Observable>
   struct infinite : public operator_base<T> {
     typedef rxu::decay_t<Observable> source_type;

--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -124,6 +124,16 @@ struct repeat : public operator_base<T>
     }
 };
 
+  template <class T, class Observable, class Count>
+  struct repeat_finite : public repeat_base<T, Observable, Count> {
+  };
+
+  template <class T, class Observable, class Count>
+  struct repeat_infinite : public repeat_base<T, Observable, Count> {
+  };
+
+  
+
 }
 
 /*! @copydoc rx-repeat.hpp
@@ -143,7 +153,7 @@ struct member_overload<repeat_tag>
         class Enabled = rxu::enable_if_all_true_type_t<
             is_observable<Observable>>,
         class SourceValue = rxu::value_type_t<Observable>,
-        class Repeat = rxo::detail::repeat<SourceValue, rxu::decay_t<Observable>, int>,
+        class Repeat = rxo::detail::repeat_infinite<SourceValue, rxu::decay_t<Observable> >,
         class Value = rxu::value_type_t<Repeat>,
         class Result = observable<Value, Repeat>>
     static Result member(Observable&& o) {
@@ -155,7 +165,7 @@ struct member_overload<repeat_tag>
         class Enabled = rxu::enable_if_all_true_type_t<
             is_observable<Observable>>,
         class SourceValue = rxu::value_type_t<Observable>,
-        class Repeat = rxo::detail::repeat<SourceValue, rxu::decay_t<Observable>, rxu::decay_t<Count>>,
+        class Repeat = rxo::detail::repeat_finite<SourceValue, rxu::decay_t<Observable>, rxu::decay_t<Count>>,
         class Value = rxu::value_type_t<Repeat>,
         class Result = observable<Value, Repeat>>
     static Result member(Observable&& o, Count&& c) {

--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -117,7 +117,6 @@ namespace repeat {
       }
       
       inline void on_completed() {
-        // Decrement counter and check if it's zero
         --remaining_;
       }
 

--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -42,107 +42,127 @@ struct repeat_invalid : public rxo::operator_base<repeat_invalid_arguments<AN...
 template<class... AN>
 using repeat_invalid_t = typename repeat_invalid<AN...>::type;
 
-  template<class RepeatConcrete, class T, class Observable, class Count>
-struct repeat_base : public operator_base<T>
-{
+// Contain repeat variations in a namespace
+namespace repeat {
+  template <class ValuesType, class Subscriber, class T>
+  struct state_type : public std::enable_shared_from_this<state_type<ValuesType, Subscriber, T>>,
+                      public ValuesType {
+
+    typedef Subscriber output_type;
+    state_type(const ValuesType& i, const output_type& oarg)
+      : ValuesType(i),
+        source_lifetime(composite_subscription::empty()),
+        out(oarg) {
+    }
+          
+    void do_subscribe() {
+      auto state = this->shared_from_this();
+                
+      state->out.remove(state->lifetime_token);
+      state->source_lifetime.unsubscribe();
+
+      state->source_lifetime = composite_subscription();
+      state->lifetime_token = state->out.add(state->source_lifetime);
+
+      state->source.subscribe(
+                              state->out,
+                              state->source_lifetime,
+                              // on_next
+                              [state](T t) {
+                                state->out.on_next(t);
+                              },
+                              // on_error
+                              [state](std::exception_ptr e) {
+                                state->out.on_error(e);
+                              },
+                              // on_completed
+                              [state]() {
+                                if (state->on_completed_predicate()) {
+                                  state->out.on_completed();
+                                } else {
+                                  state->do_subscribe();
+                                }
+                              }
+                              );
+    }
+          
+    composite_subscription source_lifetime;
+    output_type out;
+    composite_subscription::weak_subscription lifetime_token;
+  };
+
+  template <class T, class Observable, class Count>
+  struct finite : public operator_base<T> {
     typedef rxu::decay_t<Observable> source_type;
     typedef rxu::decay_t<Count> count_type;
-    struct values
-    {
-        values(source_type s, count_type t)
-            : source(std::move(s))
-            , remaining(std::move(t))
-            , repeat_infinitely(t == 0)
-        {
-        }
-        source_type source;
-        count_type remaining;
-        bool repeat_infinitely;
-    };
-    values initial;
 
-    repeat(source_type s, count_type t)
-        : initial(std::move(s), std::move(t))
-    {
+    struct values {
+      values(source_type s, count_type t)
+        : source(std::move(s)),
+          remaining_(std::move(t)) {
+      }
+
+      inline bool on_completed_predicate() {
+        // Decrement counter and check if it's zero
+        return --remaining_ <= 0;
+      }
+
+      source_type source;
+    
+    private:
+      count_type remaining_;
+    };
+    
+    finite(source_type s, count_type t)
+      : initial_(std::move(s), std::move(t)) {
     }
 
     template<class Subscriber>
     void on_subscribe(const Subscriber& s) const {
-
-        typedef Subscriber output_type;
-        struct state_type
-            : public std::enable_shared_from_this<state_type>
-            , public values
-        {
-            state_type(const values& i, const output_type& oarg)
-                : values(i)
-                , source_lifetime(composite_subscription::empty())
-                , out(oarg)
-            {
-            }
-            composite_subscription source_lifetime;
-            output_type out;
-            composite_subscription::weak_subscription lifetime_token;
-
-            void do_subscribe() {
-                auto state = this->shared_from_this();
-                
-                state->out.remove(state->lifetime_token);
-                state->source_lifetime.unsubscribe();
-
-                state->source_lifetime = composite_subscription();
-                state->lifetime_token = state->out.add(state->source_lifetime);
-
-                state->source.subscribe(
-                    state->out,
-                    state->source_lifetime,
-                // on_next
-                    [state](T t) {
-                        state->out.on_next(t);
-                    },
-                // on_error
-                    [state](std::exception_ptr e) {
-                        state->out.on_error(e);
-                    },
-                // on_completed
-                    [state]() {
-                      if (RepeatConcrete::on_completed_predicate(state->remaining)) {
-                        state->out.on_completed();
-                      } else {
-                        state->do_subscribe();
-                      }
-                    }
-                );
-            }
-        };
-
-        // take a copy of the values for each subscription
-        auto state = std::make_shared<state_type>(initial, s);
-
-        // start the first iteration
-        state->do_subscribe();
+      typedef state_type<values, Subscriber, T> state_t;
+      // take a copy of the values for each subscription
+      auto state = std::make_shared<state_t>(initial_, s);
+      // start the first iteration
+      state->do_subscribe();
     }
-};
 
-  template <class T, class Observable, class Count>
-  struct repeat_finite : public repeat_base<repeat_finite<T, Observable, Count>,
-                                            T, Observable, Count> {
-    typedef rxu::decay_t<Count> count_type;
-    static inline bool on_completed_predicate(const count_type& remaining) {
-      return --remaining <= 0;
-    }
+  private:
+    values initial_;
   };
 
-  template <class T, class Observable, class Count>
-  struct repeat_infinite : public repeat_base<repeat_finite<T, Observable, Count>,
-                                              T, Observable, Count> {
-    typedef rxu::decay_t<Count> count_type;
-    static inline bool on_completed_predicate(const count_type& remaining) {
-      return false;
-    }
-  };
+  template <class T, class Observable>
+  struct infinite : public operator_base<T> {
+    typedef rxu::decay_t<Observable> source_type;
+    
+    struct values {
+      values(source_type s)
+        : source(std::move(s)) {
+      }
 
-  
+      static inline bool on_completed_predicate() {
+        // Infinite repeat never completes
+        return false;
+      }
+
+      source_type source;
+    };
+    
+    infinite(source_type s) : initial_(std::move(s)) {
+    }
+
+    template<class Subscriber>
+    void on_subscribe(const Subscriber& s) const {
+      typedef state_type<values, Subscriber, T> state_t;
+      // take a copy of the values for each subscription
+      auto state = std::make_shared<state_t>(initial_, s);
+      // start the first iteration
+      state->do_subscribe();
+    }
+
+  private:
+    values initial_;
+  };
+}
 
 }
 
@@ -157,37 +177,34 @@ auto repeat(AN&&... an)
 }
 
 template<>
-struct member_overload<repeat_tag>
-{
-    template<class Observable,
-        class Enabled = rxu::enable_if_all_true_type_t<
-            is_observable<Observable>>,
-        class SourceValue = rxu::value_type_t<Observable>,
-        class Repeat = rxo::detail::repeat_infinite<SourceValue, rxu::decay_t<Observable> >,
-        class Value = rxu::value_type_t<Repeat>,
-        class Result = observable<Value, Repeat>>
-    static Result member(Observable&& o) {
-        return Result(Repeat(std::forward<Observable>(o), 0));
-    }
+struct member_overload<repeat_tag> {
+  template<class Observable,
+           class Enabled = rxu::enable_if_all_true_type_t<is_observable<Observable>>,
+           class SourceValue = rxu::value_type_t<Observable>,
+           class Repeat = rxo::detail::repeat::infinite<SourceValue, rxu::decay_t<Observable>>,
+           class Value = rxu::value_type_t<Repeat>,
+           class Result = observable<Value, Repeat>>
+  static Result member(Observable&& o) {
+    return Result(Repeat(std::forward<Observable>(o)));
+  }
 
-    template<class Observable,
-        class Count,
-        class Enabled = rxu::enable_if_all_true_type_t<
-            is_observable<Observable>>,
-        class SourceValue = rxu::value_type_t<Observable>,
-        class Repeat = rxo::detail::repeat_finite<SourceValue, rxu::decay_t<Observable>, rxu::decay_t<Count>>,
-        class Value = rxu::value_type_t<Repeat>,
-        class Result = observable<Value, Repeat>>
-    static Result member(Observable&& o, Count&& c) {
-        return Result(Repeat(std::forward<Observable>(o), std::forward<Count>(c)));
-    }
+  template<class Observable,
+           class Count,
+           class Enabled = rxu::enable_if_all_true_type_t<is_observable<Observable>>,
+           class SourceValue = rxu::value_type_t<Observable>,
+           class Repeat = rxo::detail::repeat::finite<SourceValue, rxu::decay_t<Observable>, rxu::decay_t<Count>>,
+           class Value = rxu::value_type_t<Repeat>,
+           class Result = observable<Value, Repeat>>
+  static Result member(Observable&& o, Count&& c) {
+    return Result(Repeat(std::forward<Observable>(o), std::forward<Count>(c)));
+  }
 
-    template<class... AN>
-    static operators::detail::repeat_invalid_t<AN...> member(AN...) {
-        std::terminate();
-        return {};
-        static_assert(sizeof...(AN) == 10000, "repeat takes (optional Count)");
-    }
+  template<class... AN>
+  static operators::detail::repeat_invalid_t<AN...> member(AN...) {
+    std::terminate();
+    return {};
+    static_assert(sizeof...(AN) == 10000, "repeat takes (optional Count)");
+  }
 };
 
 }

--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -8,7 +8,7 @@
 
     \tparam Count  the type of the counter (optional).
 
-    \param t  the number of times the source observable items are repeated (optional). If not specified, infinitely repeats the source observable.
+    \param t The number of times the source observable items are repeated (optional). If not specified, infinitely repeats the source observable. Specifying 0 returns an empty sequence immediately
 
     \return  An observable that repeats the sequence of items emitted by the source observable for t times.
 

--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -130,9 +130,12 @@ namespace repeat {
     template<class Subscriber>
     void on_subscribe(const Subscriber& s) const {
       typedef state_type<values, Subscriber, T> state_t;
-      if (!initial_.completed_predicate()) {
-        // take a copy of the values for each subscription
-        auto state = std::make_shared<state_t>(initial_, s);
+      // take a copy of the values for each subscription
+      auto state = std::make_shared<state_t>(initial_, s);      
+      if (initial_.completed_predicate()) {
+        // return completed
+        state->out.on_completed();
+      } else {
         // start the first iteration
         state->do_subscribe();
       }

--- a/Rx/v2/test/operators/repeat.cpp
+++ b/Rx/v2/test/operators/repeat.cpp
@@ -88,6 +88,11 @@ SCENARIO("repeat, 0 times case", "[repeat][operators]"){
               REQUIRE(required == actual);
             }
 
+            THEN("no subscriptions in repeat(0) variant that skips on.next()"){
+              auto required = std::vector<rxcpp::notifications::subscription>();
+              auto actual = xs.subscriptions();
+              REQUIRE(required == actual);
+            }
         }
     }
 }

--- a/Rx/v2/test/operators/repeat.cpp
+++ b/Rx/v2/test/operators/repeat.cpp
@@ -69,7 +69,7 @@ SCENARIO("repeat, 0 times case", "[repeat][operators]"){
             on.completed(250)
         });
 
-        WHEN("infinite repeat is launched"){
+        WHEN("repeat zero times is launched"){
 
             auto res = w.start(
                 [&]() {
@@ -81,7 +81,10 @@ SCENARIO("repeat, 0 times case", "[repeat][operators]"){
             );
 
             THEN("the output should be empty"){
-                auto required = std::vector<rxsc::test::messages<int>::recorded_type>();
+              auto required = rxu::to_vector({
+                    on.completed(450)
+                });
+
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
             }

--- a/Rx/v2/test/operators/repeat.cpp
+++ b/Rx/v2/test/operators/repeat.cpp
@@ -81,10 +81,7 @@ SCENARIO("repeat, 0 times case", "[repeat][operators]"){
             );
 
             THEN("the output should be empty"){
-              auto required = rxu::to_vector({
-                    on.completed(450)
-                });
-
+                auto required = std::vector<rxsc::test::messages<int>::recorded_type>();
                 auto actual = res.get_observer().messages();
                 REQUIRE(required == actual);
             }

--- a/Rx/v2/test/operators/repeat.cpp
+++ b/Rx/v2/test/operators/repeat.cpp
@@ -81,9 +81,11 @@ SCENARIO("repeat, 0 times case", "[repeat][operators]"){
             );
 
             THEN("the output should be empty"){
-                auto required = std::vector<rxsc::test::messages<int>::recorded_type>();
-                auto actual = res.get_observer().messages();
-                REQUIRE(required == actual);
+              auto required = rxu::to_vector({
+                  on.completed(200)
+                    });
+              auto actual = res.get_observer().messages();
+              REQUIRE(required == actual);
             }
 
         }

--- a/Rx/v2/test/operators/repeat.cpp
+++ b/Rx/v2/test/operators/repeat.cpp
@@ -56,6 +56,40 @@ SCENARIO("repeat, basic test", "[repeat][operators]"){
     }
 }
 
+SCENARIO("repeat, 0 times case", "[repeat][operators]"){
+    GIVEN("cold observable of 3 ints."){
+        auto sc = rxsc::make_test();
+        auto w = sc.create_worker();
+        const rxsc::test::messages<int> on;
+
+        auto xs = sc.make_cold_observable({
+            on.next(100, 1),
+            on.next(150, 2),
+            on.next(200, 3),
+            on.completed(250)
+        });
+
+        WHEN("infinite repeat is launched"){
+
+            auto res = w.start(
+                [&]() {
+                    return xs
+                        | rxo::repeat(0)
+                        // forget type to workaround lambda deduction bug on msvc 2013
+                        | rxo::as_dynamic();
+                }
+            );
+
+            THEN("the output should be empty"){
+                auto required = std::vector<rxsc::test::messages<int>::recorded_type>();
+                auto actual = res.get_observer().messages();
+                REQUIRE(required == actual);
+            }
+
+        }
+    }
+}
+
 SCENARIO("repeat, infinite observable test", "[repeat][operators]"){
     GIVEN("cold observable of 3 ints that never completes."){
         auto sc = rxsc::make_test();


### PR DESCRIPTION
This rewrite addresses two isssues.
1. Rx operator repeat with 0 time argument should return an empty sequence. The reasons for that:
  * Rx API is designed based on traditional functional programming and the fact that Iterator/Observer patterns are functional duals. Repeat function with times argument in non-lazy languages with Iterator-implemented sequences returns empty sequence when called with 0 as times argument, it's natural for the Observer dual to behave simiraly
  * Using 0 as "magic number" breaks algorithmic generality, i.e. passing a dynamic counter variable to repeat as argument leads to unexpected result
  * Rx in other languages treat 0 that way (e.g. https://github.com/ReactiveX/RxJava/blob/1.x/src/main/java/rx/Observable.java#L8536 )

2. Get rid of dependency on dynamic state counter. Infinite repeat implementation should not be coupled with finite repeat, it should not make run-time checks for the finiteness flag