### PR TITLE
Work-around for VS2017RC error C2672 building doc

### DIFF
--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -1435,7 +1435,7 @@ public:
         -> decltype(observable_member(retry_tag{}, *(this_type*)nullptr, std::forward<AN>(an)...))
         /// \endcond
     {
-        return      observable_member(retry_tag{},                *this, std::forward<AN>(an)...);
+        return      observable_member(retry_tag{},                *(this_type*)this, std::forward<AN>(an)...);
     }
 
     /*! @copydoc rx-start_with.hpp


### PR DESCRIPTION
When building RxCPP with the latest VS2017 RC, the compiler emits error
C2672 on compiling a method.

There was some off-line discussion (Kirk Shoop was included) about the
legitimacy of the error. In either case, I'd anticipate that the error
could hit in VS2017RTW, so I'm offering this PR.

The change is very targeted -- a natural question is if this error could
arise in the methods around retry. For that and further discussion, I
have to point you to my colleagues participating in the off-line
discussion; for this particular patch all I could do was confirm the
latest RC still needs it to build.