### PR TITLE
Retry(0)/Retry() operator fix

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-retry.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-retry.hpp
@@ -66,6 +66,7 @@ namespace retry {
                               },
                               // on_error
                               [state](std::exception_ptr e) {
+                                state->update();
                                 // Use specialized predicate for finite/infinte case
                                 if (state->completed_predicate()) {
                                   state->out.on_error(e);                                  
@@ -94,8 +95,7 @@ namespace retry {
     struct values {
       values(source_type s, count_type t)
         : source(std::move(s)), remaining_(std::move(t)) {
-        // One "retry" in the counter is actually the first (normal) try 
-        --remaining_;
+        if (remaining_ != 0) ++remaining_;
       }
       
       inline bool completed_predicate() const {
@@ -103,7 +103,7 @@ namespace retry {
         return remaining_ <= 0;
       }
       
-      inline void on_completed() {
+      inline void update() {
         // Decrement counter
         --remaining_;
       }
@@ -151,7 +151,7 @@ namespace retry {
         return false;
       }
       
-      static inline void on_completed() {
+      static inline void update() {
         // Infinite retry does not need to update state
       }
 

--- a/Rx/v2/src/rxcpp/operators/rx-retry.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-retry.hpp
@@ -8,7 +8,7 @@
 
     \tparam Count the type of the counter (optional)
 
-    \param t  the number of retries (optional) If not specified or 0, infinitely retries the source observable.
+    \param t  the number of retries (optional) If not specified, infinitely retries the source observable. Sepcifying returns immediately without subscribing
 
     \return  An observable that mirrors the source observable, resubscribing to it if it calls on_error up to a specified number of retries.
 

--- a/Rx/v2/test/operators/retry.cpp
+++ b/Rx/v2/test/operators/retry.cpp
@@ -1,7 +1,6 @@
 #include "../test.h"
 #include "rxcpp/operators/rx-retry.hpp"
 
-
 SCENARIO("retry, basic test", "[retry][operators]") {
     GIVEN("hot observable of 3x4x7 ints with errors inbetween the groups. Infinite retry.") {
         auto sc = rxsc::make_test();
@@ -75,6 +74,49 @@ SCENARIO("retry, basic test", "[retry][operators]") {
     }
 }
 
+SCENARIO("retry 0, basic test", "[retry][operators]") {
+  GIVEN("hot observable of 3 ints. Infinite retry.") {
+    auto sc = rxsc::make_test();
+    auto w = sc.create_worker();
+    const rxsc::test::messages<int> on;
+    std::runtime_error ex("retry on_error from source");
+
+    auto xs = sc.make_hot_observable({
+        on.next(100, 1),
+          on.next(150, 2),
+          on.next(200, 3),
+          });;
+
+    WHEN("retry is invoked with 0 times as argument") {
+
+      auto res = w.start(
+                         [&]() {
+                           return xs
+                           | rxo::retry(0)
+                           // forget type to workaround lambda deduction bug on msvc 2013
+                           | rxo::as_dynamic();
+                         }
+                         );
+      
+      THEN("the output should be empty"){
+        auto required = rxu::to_vector({
+            on.completed(200)
+              });
+        auto actual = res.get_observer().messages();
+        REQUIRE(required == actual);
+      }
+
+      THEN("no subscriptions in retry(0)"){
+        auto required = std::vector<rxcpp::notifications::subscription>();
+        auto actual = xs.subscriptions();
+        REQUIRE(required == actual);
+      }
+
+    }
+
+  }
+}
+          
 
 SCENARIO("retry with failure", "[retry][operators]") {
     GIVEN("hot observable of 3x4x7 ints with errors inbetween the groups. Retry 1. Must fail.") {


### PR DESCRIPTION
Fix 0 as magic number for infinite retry and decouple finite/infinite cases. 

This is similar to #356