### PR TITLE
fix iterator_type::value_type error

### DIFF
--- a/Rx/v2/src/rxcpp/sources/rx-iterate.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-iterate.hpp
@@ -53,7 +53,7 @@ template<class Collection>
 struct iterate_traits
 {
     typedef rxu::decay_t<Collection> collection_type;
-    typedef decltype(std::begin(*(collection_type*)nullptr)) iterator_type;
+    typedef rxu::decay_t<decltype(std::begin(*(collection_type*)nullptr))> iterator_type;
     typedef rxu::value_type_t<std::iterator_traits<iterator_type>> value_type;
 };
 


### PR DESCRIPTION
#355 reported that range-v3 ranges failed due to an errant `&` in the
`iterator_type`