### PR TITLE
Retry: subscription lifetime; repeat: generic naming

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -78,7 +78,7 @@ namespace repeat {
                               },
                               // on_completed
                               [state]() {
-                                state->on_completed();
+                                state->update();
                                 // Use specialized predicate for finite/infinte case
                                 if (state->completed_predicate()) {
                                   state->out.on_completed();
@@ -111,7 +111,7 @@ namespace repeat {
         return remaining_ <= 0;
       }
       
-      inline void on_completed() {
+      inline void update() {
         // Decrement counter
         --remaining_;
       }
@@ -142,7 +142,7 @@ namespace repeat {
     }
 
   private:
-    values initial_;
+     values initial_;
   };
 
   // Infinite repeat case
@@ -160,7 +160,7 @@ namespace repeat {
         return false;
       }
 
-      static inline void on_completed() {
+      static inline void update() {
         // Infinite repeat does not need to update state
       }
 

--- a/Rx/v2/src/rxcpp/operators/rx-retry.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-retry.hpp
@@ -8,7 +8,7 @@
 
     \tparam Count the type of the counter (optional)
 
-    \param t  the number of retries (optional) If not specified, infinitely retries the source observable. Sepcifying returns immediately without subscribing
+    \param t  the number of retries (optional) If not specified, infinitely retries the source observable. Specifying returns immediately without subscribing
 
     \return  An observable that mirrors the source observable, resubscribing to it if it calls on_error up to a specified number of retries.
 
@@ -54,8 +54,12 @@ namespace retry {
     void do_subscribe() {
       auto state = this->shared_from_this();
 
+      state->out.remove(state->lifetime_token);
+      state->source_lifetime.unsubscribe();
+
       state->source_lifetime = composite_subscription();
-      state->out.add(state->source_lifetime);
+      state->lifetime_token = state->out.add(state->source_lifetime);
+
 
       state->source.subscribe(
                               state->out,
@@ -84,6 +88,7 @@ namespace retry {
     
     composite_subscription source_lifetime;
     output_type out;
+    composite_subscription::weak_subscription lifetime_token;
   };
 
   // Finite retry case (explicitly limited with the number of times)


### PR DESCRIPTION
Add subscription tracking to retry operator to mange lifetime.

Change method naming in repeat operator implementation to match generically with retry