### PR TITLE
Retry operator argument semantics fix

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -78,7 +78,7 @@ namespace repeat {
                               },
                               // on_completed
                               [state]() {
-                                state->on_completed();
+                                state->update();
                                 // Use specialized predicate for finite/infinte case
                                 if (state->completed_predicate()) {
                                   state->out.on_completed();
@@ -111,7 +111,7 @@ namespace repeat {
         return remaining_ <= 0;
       }
       
-      inline void on_completed() {
+      inline void update() {
         // Decrement counter
         --remaining_;
       }
@@ -160,7 +160,7 @@ namespace repeat {
         return false;
       }
 
-      static inline void on_completed() {
+      static inline void update() {
         // Infinite repeat does not need to update state
       }
 

--- a/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-repeat.hpp
@@ -78,7 +78,7 @@ namespace repeat {
                               },
                               // on_completed
                               [state]() {
-                                state->update();
+                                state->on_completed();
                                 // Use specialized predicate for finite/infinte case
                                 if (state->completed_predicate()) {
                                   state->out.on_completed();
@@ -111,7 +111,7 @@ namespace repeat {
         return remaining_ <= 0;
       }
       
-      inline void update() {
+      inline void on_completed() {
         // Decrement counter
         --remaining_;
       }
@@ -160,7 +160,7 @@ namespace repeat {
         return false;
       }
 
-      static inline void update() {
+      static inline void on_completed() {
         // Infinite repeat does not need to update state
       }
 

--- a/Rx/v2/src/rxcpp/operators/rx-retry.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-retry.hpp
@@ -8,7 +8,7 @@
 
     \tparam Count the type of the counter (optional)
 
-    \param t  the total number of retries (optional), i.e. retry(2) means one normal try and one retry. If not specified, infinitely retries the source observable. Specifying 0 returns immediately without subscribing
+    \param t  the total number of tries (optional), i.e. retry(2) means one normal try, before an error occurs, and one retry. If not specified, infinitely retries the source observable. Specifying 0 returns immediately without subscribing
 
     \return  An observable that mirrors the source observable, resubscribing to it if it calls on_error up to a specified number of retries.
 

--- a/Rx/v2/src/rxcpp/operators/rx-retry.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-retry.hpp
@@ -8,7 +8,7 @@
 
     \tparam Count the type of the counter (optional)
 
-    \param t  the number of retries (optional) If not specified, infinitely retries the source observable. Sepcifying returns immediately without subscribing
+    \param t  the number of retries (optional) If not specified, infinitely retries the source observable. Specifying returns immediately without subscribing
 
     \return  An observable that mirrors the source observable, resubscribing to it if it calls on_error up to a specified number of retries.
 
@@ -54,8 +54,11 @@ namespace retry {
     void do_subscribe() {
       auto state = this->shared_from_this();
 
+      state->out.remove(state->lifetime_token);
+      state->source_lifetime.unsubscribe();
+
       state->source_lifetime = composite_subscription();
-      state->out.add(state->source_lifetime);
+      state->lifetime_token = state->out.add(state->source_lifetime);
 
       state->source.subscribe(
                               state->out,
@@ -84,6 +87,7 @@ namespace retry {
     
     composite_subscription source_lifetime;
     output_type out;
+    composite_subscription::weak_subscription lifetime_token;
   };
 
   // Finite retry case (explicitly limited with the number of times)

--- a/Rx/v2/src/rxcpp/operators/rx-retry.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-retry.hpp
@@ -8,7 +8,7 @@
 
     \tparam Count the type of the counter (optional)
 
-    \param t  the number of retries (optional) If not specified, infinitely retries the source observable. Specifying returns immediately without subscribing
+    \param t  the total number of retries (optional), i.e. retry(2) means one normal try and one retry. If not specified, infinitely retries the source observable. Specifying 0 returns immediately without subscribing
 
     \return  An observable that mirrors the source observable, resubscribing to it if it calls on_error up to a specified number of retries.
 
@@ -100,7 +100,6 @@ namespace retry {
     struct values {
       values(source_type s, count_type t)
         : source(std::move(s)), remaining_(std::move(t)) {
-        if (remaining_ != 0) ++remaining_;
       }
       
       inline bool completed_predicate() const {

--- a/Rx/v2/src/rxcpp/operators/rx-retry.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-retry.hpp
@@ -8,7 +8,7 @@
 
     \tparam Count the type of the counter (optional)
 
-    \param t  the number of retries (optional) If not specified, infinitely retries the source observable. Specifying returns immediately without subscribing
+    \param t  the number of retries (optional) If not specified, infinitely retries the source observable. Sepcifying returns immediately without subscribing
 
     \return  An observable that mirrors the source observable, resubscribing to it if it calls on_error up to a specified number of retries.
 
@@ -54,11 +54,8 @@ namespace retry {
     void do_subscribe() {
       auto state = this->shared_from_this();
 
-      state->out.remove(state->lifetime_token);
-      state->source_lifetime.unsubscribe();
-
       state->source_lifetime = composite_subscription();
-      state->lifetime_token = state->out.add(state->source_lifetime);
+      state->out.add(state->source_lifetime);
 
       state->source.subscribe(
                               state->out,
@@ -87,7 +84,6 @@ namespace retry {
     
     composite_subscription source_lifetime;
     output_type out;
-    composite_subscription::weak_subscription lifetime_token;
   };
 
   // Finite retry case (explicitly limited with the number of times)

--- a/Rx/v2/test/operators/retry.cpp
+++ b/Rx/v2/test/operators/retry.cpp
@@ -119,7 +119,7 @@ SCENARIO("retry 0, basic test", "[retry][operators]") {
           
 
 SCENARIO("retry with failure", "[retry][operators]") {
-    GIVEN("hot observable of 3x4x7 ints with errors inbetween the groups. Retry 1. Must fail.") {
+    GIVEN("hot observable of 3x4x7 ints with errors inbetween the groups. Retry 2. Must fail.") {
         auto sc = rxsc::make_test();
         auto w = sc.create_worker();
         const rxsc::test::messages<int> on;
@@ -145,12 +145,12 @@ SCENARIO("retry with failure", "[retry][operators]") {
             on.completed(725)
         });
 
-        WHEN("retry of 1 is launched with expected error before complete") {
+        WHEN("retry of 2 is launched with expected error before complete") {
 
             auto res = w.start(
                 [&]() {
                 return xs
-                    .retry(1)
+                    .retry(2)
                     // forget type to workaround lambda deduction bug on msvc 2013
                     .as_dynamic();
             });


### PR DESCRIPTION
Change the parameter of retry to be counted one more time. 

The parameter 'times' in retry operator actually means the total number of tries, not the number of retries. This is some misunderstanding due to operator's naming and is explicitly documented in some Rx implementation descriptions:
* RxNet: http://www.introtorx.com/uat/content/v1.0.10621.0/11_FlowControl.html#Retry
* RxJS: https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/retry.md 