### PR TITLE
appveyor vs2017 image update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,12 @@ image: Visual Studio 2017
 
 environment:
   matrix:
-    - VSVER: Visual Studio 12 2013 Win64
-    - VSVER: Visual Studio 14 2015 Win64
-    - VSVER: Visual Studio 15 2017 Win64
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+    VSVER: Visual Studio 12 2013 Win64
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    VSVER: Visual Studio 14 2015 Win64
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    VSVER: Visual Studio 15 2017 Win64
 
 platform:
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
         - master
         - appveyor
 
-image: Visual Studio 2017 RC
+image: Visual Studio 2017
 
 environment:
   matrix:


### PR DESCRIPTION
Visual Studio 2017 is released and AppVeyor removed the RC image.
Made changes to the appveyor-config file to fix the [broken](https://ci.appveyor.com/project/kirkshoop/rxcpp-446/build/2.2.608) build

Please review.

Thank you,
Grigoriy