### PR TITLE
fixed https://github.com/Reactive-Extensions/RxCpp/issues/366

### DIFF
--- a/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
@@ -340,8 +340,9 @@ public:
 template<class T>
 rxt::testable_observable<T> test_type::make_hot_observable(std::vector<rxn::recorded<std::shared_ptr<rxn::detail::notification_base<T>>>> messages) const
 {
-    return rxt::testable_observable<T>(
-        std::make_shared<hot_observable<T>>(state, create_worker(composite_subscription()), std::move(messages)));
+    auto worker = create_worker(composite_subscription());
+    auto shared = std::make_shared<hot_observable<T>>(state, worker, std::move(messages));
+    return rxt::testable_observable<T>(shared);
 }
 
 template<class F>


### PR DESCRIPTION
I have no a rational explanation of my changes (may be optimizer does something wrong with a problem expression, I do not know), but now all tests passed with 32 bit release (with/without v140_xp):

`100% tests passed, 0 tests failed out of 65`

I found the minimal code which reproduces the problem with RelWithDebInfo build:

```
int main()
{
    auto sc = rxsc::make_test();
std::vector<rxcpp::notifications::recorded<std::shared_ptr<rxcpp::notifications::detail::notification_base<int> > > > v;
    auto xs = sc.make_hot_observable(v); // here is segmentation fault
    return 0;
}
```

which failed in depth of std::make_shared:

```
return rxt::testable_observable<T>(
        std::make_shared<hot_observable<T>>(state, create_worker(composite_subscription()), std::move(messages)));
``` 

After that I simplified the expression with local intermediate variables:

```
    auto worker = create_worker(composite_subscription());
    auto shared = std::make_shared<hot_observable<T>>(state, worker, std::move(messages));
    return rxt::testable_observable<T>(shared);
```

and the problem  disappeared. 
