### PR TITLE
Add CMake option to not build and run test and examples

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
 project(rxcpp VERSION 2.2.4 LANGUAGES C CXX)
 
+option(RXCPP_BUILD_TESTS "Enable the build of tests and samples." ON)
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # define some folders
@@ -11,18 +13,22 @@ get_filename_component(RXCPP_DIR "${RXCPP_DIR}" PATH)
 
 MESSAGE( STATUS "RXCPP_DIR: " ${RXCPP_DIR} )
 
-add_subdirectory(${RXCPP_DIR}/Rx/v2/test ${CMAKE_CURRENT_BINARY_DIR}/test)
+if(RXCPP_BUILD_TESTS)
+   add_subdirectory(${RXCPP_DIR}/Rx/v2/test ${CMAKE_CURRENT_BINARY_DIR}/test)
+endif()
 
 add_subdirectory(${RXCPP_DIR}/projects/doxygen ${CMAKE_CURRENT_BINARY_DIR}/projects/doxygen)
 
 set(EXAMPLES_DIR ${RXCPP_DIR}/Rx/v2/examples)
 
-add_subdirectory(${EXAMPLES_DIR}/cep ${CMAKE_CURRENT_BINARY_DIR}/examples/cep)
-add_subdirectory(${EXAMPLES_DIR}/stop ${CMAKE_CURRENT_BINARY_DIR}/examples/stop)
-add_subdirectory(${EXAMPLES_DIR}/linesfrombytes ${CMAKE_CURRENT_BINARY_DIR}/examples/linesfrombytes)
-add_subdirectory(${EXAMPLES_DIR}/println ${CMAKE_CURRENT_BINARY_DIR}/examples/println)
-add_subdirectory(${EXAMPLES_DIR}/pythagorian ${CMAKE_CURRENT_BINARY_DIR}/examples/pythagorian)
-add_subdirectory(${EXAMPLES_DIR}/tests ${CMAKE_CURRENT_BINARY_DIR}/examples/tests)
+if(RXCPP_BUILD_TESTS)
+   add_subdirectory(${EXAMPLES_DIR}/cep ${CMAKE_CURRENT_BINARY_DIR}/examples/cep)
+   add_subdirectory(${EXAMPLES_DIR}/stop ${CMAKE_CURRENT_BINARY_DIR}/examples/stop)
+   add_subdirectory(${EXAMPLES_DIR}/linesfrombytes ${CMAKE_CURRENT_BINARY_DIR}/examples/linesfrombytes)
+   add_subdirectory(${EXAMPLES_DIR}/println ${CMAKE_CURRENT_BINARY_DIR}/examples/println)
+   add_subdirectory(${EXAMPLES_DIR}/pythagorian ${CMAKE_CURRENT_BINARY_DIR}/examples/pythagorian)
+   add_subdirectory(${EXAMPLES_DIR}/tests ${CMAKE_CURRENT_BINARY_DIR}/examples/tests)
+endif()
 
 # The list of RxCpp source files. Please add every new file to this list
 set(RX_SOURCES


### PR DESCRIPTION
It's super great that RxCpp has such a comprehensive set of tests and examples, but when I include RxCpp in my own (CMake based) project, I am not particularly interested in compiling them (which takes a significant amount of time, especially compared to the rest of my project) or running the tests with CTest.

CMake has a nice `EXCLUDE_FROM_ALL` option to its `add_subdirectory` command which makes it build only things that you depend on explicitly, but unfortunately it does not interact well with CTest. If I use `EXCLUDE_FROM_ALL` on RxCpp, then `ctest` fails because it attempts to run tests that were not built.

[As far as I know](http://stackoverflow.com/questions/23713650/cmake-exclude-tests-in-subdirectories) there is no sane way to disable CTest tests once they have been registered, and the idiomatic CMake approach seems to be to have an option like this that optionally disables tests and similar things. [Flatbuffers do this, for example](https://github.com/google/flatbuffers/blob/master/CMakeLists.txt#L7).

With this patch, I will be able to import RxCpp to my project like this:

    set(RXCPP_BUILD_TESTS OFF)
    add_subdirectory(rxcpp)