### PR TITLE
Add get_subscription() for subject

### DIFF
--- a/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
@@ -254,6 +254,10 @@ public:
         return s.has_observers();
     }
 
+    composite_subscription get_subscription() const {
+        return s.get_subscription();
+    }
+
     subscriber_type get_subscriber() const {
         return s.get_subscriber();
     }


### PR DESCRIPTION
I think this little code piece is harmless and meaningful.

Further explaining, there are two constructor of subject: 
```C++
    subject()
        : s(composite_subscription())
    {
    }
    explicit subject(composite_subscription cs)
        : s(cs)
    {
    }
```
to retrieve the auto-created subscription(in 1st constructor), we need a get_subscription() for subject.


