### PR TITLE
std::unexpected has been deprecated

### DIFF
--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -693,7 +693,7 @@ public:
             try {
                 (*function)();
             } catch (...) {
-                std::unexpected();
+                std::terminate();
             }
         }
     }


### PR DESCRIPTION
fix for #388