### PR TITLE
Add 'include' to the install path of the headers

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -133,5 +133,5 @@ SET_TARGET_PROPERTIES(RxCpp PROPERTIES LINKER_LANGUAGE CXX)
 
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE CACHE BOOL "Don't require all projects to be built in order to install" FORCE)
 
-install(DIRECTORY ${RXCPP_DIR}/Rx/v2/src/rxcpp/ DESTINATION rxcpp
+install(DIRECTORY ${RXCPP_DIR}/Rx/v2/src/rxcpp/ DESTINATION include/rxcpp
         FILES_MATCHING PATTERN "*.hpp")


### PR DESCRIPTION
When installing the headers (as far as I see there are no library files) into the system using `make install` installs them into `/usr/local/rxcpp/...` which is not a standard place for header files...  This PR fixes that by installing them into something more like `/usr/local/include/rxcpp/...`. Of course the `/usr/local` is just my default `CMAKE_INSTALL_PREFIX` which can be changed to whatever people like. This will allow me to package rxcpp more easily into and AUR package which I'll hopefully soon make because I didnt find any out there.