### PR TITLE
Typo in rx-never documentation

### DIFF
--- a/Rx/v2/src/rxcpp/sources/rx-never.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-never.hpp
@@ -7,7 +7,7 @@
 
 #include "../rx-includes.hpp"
 
-/*! \file rx-naver.hpp
+/*! \file rx-never.hpp
 
     \brief Returns an observable that never sends any items or notifications to observer.
 


### PR DESCRIPTION
Browsing the project and found a typo. Changed "rx-naver.hpp" to "rx-never.hpp"