### PR TITLE
Fix clang-trunk -Wunused-lambda-capture warnings

### DIFF
--- a/Rx/v2/test/operators/group_by.cpp
+++ b/Rx/v2/test/operators/group_by.cpp
@@ -47,13 +47,13 @@ SCENARIO("range partitioned by group_by across hardware threads to derive pi", "
                     [](work w) -> int {return w.index % std::thread::hardware_concurrency();},
                     [](work w){return w;}).
                 map(
-                    [=, &c](rxcpp::grouped_observable<int, work> onproc) {
+                    [=](rxcpp::grouped_observable<int, work> onproc) {
                         auto key = onproc.get_key();
                         // share a producer thread across all the ranges in this group of chunks
                         auto producerthread = rxcpp::observe_on_one_worker(rxcpp::observe_on_new_thread().create_coordinator().get_scheduler());
                         return onproc.
                             map(
-                                [=, &c](work w){
+                                [=](work w){
                                     std::stringstream message;
                                     message << std::setw(3) << w.index << ": range - " << w.first << "-" << w.last;
 
@@ -123,7 +123,7 @@ SCENARIO("range partitioned by dividing work across hardware threads to derive p
                         return work{index, first, last};
                     }).
                 map(
-                    [=, &c](work w){
+                    [=](work w){
                         std::stringstream message;
                         message << std::setw(3) << w.index << ": range - " << w.first << "-" << w.last;
 

--- a/Rx/v2/test/operators/pairwise.cpp
+++ b/Rx/v2/test/operators/pairwise.cpp
@@ -21,7 +21,7 @@ SCENARIO("pairwise - enough items to create pairs", "[pairwise][operators]") {
         WHEN("taken pairwise") {
 
             auto res = w.start(
-                [xs, &invoked]() {
+                [xs]() {
                     return xs
                         | rxo::pairwise()
                         // forget type to workaround lambda deduction bug on msvc 2013

--- a/Rx/v2/test/operators/pairwise.cpp
+++ b/Rx/v2/test/operators/pairwise.cpp
@@ -7,7 +7,6 @@ SCENARIO("pairwise - enough items to create pairs", "[pairwise][operators]") {
         auto w = sc.create_worker();
         const rxsc::test::messages<int> on;
         const rxsc::test::messages<std::tuple<int, int>> on_pairwise;
-        long invoked = 0;
 
         auto xs = sc.make_cold_observable({
             on.next(180, 1),

--- a/Rx/v2/test/subjects/subject.cpp
+++ b/Rx/v2/test/subjects/subject.cpp
@@ -138,7 +138,7 @@ public:
 };
 }
 SCENARIO("for loop calls ready on_next(int)", "[hide][for][asyncobserver][ready][perf]"){
-    const int& onnextcalls = static_onnextcalls;
+    static const int& onnextcalls = static_onnextcalls;
     GIVEN("a for loop"){
         WHEN("calling on_next 100 million times"){
             using namespace std::chrono;
@@ -152,7 +152,7 @@ SCENARIO("for loop calls ready on_next(int)", "[hide][for][asyncobserver][ready]
             asyncwithready::async_subscriber<int, decltype(onnext)> scbr(onnext);
             asyncwithready::ready::onthen_type chunk;
             int i = 0;
-            chunk = [&chunk, scbr, i, onnextcalls]() mutable {
+            chunk = [&chunk, scbr, i]() mutable {
                 for (; i < onnextcalls && scbr.is_subscribed(); i++) {
                     auto controller = scbr.on_next(i);
                     if (!controller.is_ready()) {
@@ -225,13 +225,13 @@ SCENARIO("for loop calls observer", "[hide][for][observer][perf]"){
             using namespace std::chrono;
             typedef steady_clock clock;
 
-            int& c = aliased;
+            static int& c = aliased;
             int n = 1;
 
             c = 0;
             auto start = clock::now();
             auto o = rx::make_observer<int>(
-                [&c](int){++c;},
+                [](int){++c;},
                 [](std::exception_ptr){abort();});
             for (int i = 0; i < onnextcalls; i++) {
                 o.on_next(i);
@@ -251,13 +251,13 @@ SCENARIO("for loop calls subscriber", "[hide][for][subscriber][perf]"){
             using namespace std::chrono;
             typedef steady_clock clock;
 
-            int& c = aliased;
+            static int& c = aliased;
             int n = 1;
 
             c = 0;
             auto start = clock::now();
             auto o = rx::make_subscriber<int>(
-                [&c](int){++c;},
+                [](int){++c;},
                 [](std::exception_ptr){abort();});
             for (int i = 0; i < onnextcalls && o.is_subscribed(); i++) {
                 o.on_next(i);
@@ -277,14 +277,14 @@ SCENARIO("range calls subscriber", "[hide][range][subscriber][perf]"){
             using namespace std::chrono;
             typedef steady_clock clock;
 
-            int& c = aliased;
+            static int& c = aliased;
             int n = 1;
 
             c = 0;
             auto start = clock::now();
 
             rxs::range<int>(1, onnextcalls).subscribe(
-                [&c](int){
+                [](int){
                     ++c;
                 },
                 [](std::exception_ptr){abort();});
@@ -297,7 +297,7 @@ SCENARIO("range calls subscriber", "[hide][range][subscriber][perf]"){
 }
 
 SCENARIO("for loop calls subject", "[hide][for][subject][subjects][long][perf]"){
-    const int& onnextcalls = static_onnextcalls;
+    static const int& onnextcalls = static_onnextcalls;
     GIVEN("a for loop and a subject"){
         WHEN("multicasting a million ints"){
             using namespace std::chrono;
@@ -316,7 +316,7 @@ SCENARIO("for loop calls subject", "[hide][for][subject][subjects][long][perf]")
 
                 auto o = sub.get_subscriber();
 
-                o.add(rx::make_subscription([c, n, onnextcalls](){
+                o.add(rx::make_subscription([c, n](){
                     auto expected = n * onnextcalls;
                     REQUIRE(*c == expected);
                 }));
@@ -371,7 +371,7 @@ SCENARIO("for loop calls subject", "[hide][for][subject][subjects][long][perf]")
 }
 
 SCENARIO("range calls subject", "[hide][range][subject][subjects][long][perf]"){
-    const int& onnextcalls = static_onnextcalls;
+    static const int& onnextcalls = static_onnextcalls;
     GIVEN("a range and a subject"){
         WHEN("multicasting a million ints"){
             using namespace std::chrono;
@@ -389,7 +389,7 @@ SCENARIO("range calls subject", "[hide][range][subject][subjects][long][perf]"){
 
                 auto o = sub.get_subscriber();
 
-                o.add(rx::make_subscription([c, n, onnextcalls](){
+                o.add(rx::make_subscription([c, n](){
                     auto expected = n * onnextcalls;
                     REQUIRE(*c == expected);
                 }));


### PR DESCRIPTION
By default, RxCpp fails to build with clang-trunk due to `-Werror,-Wunused-lambda-capture` warnings. Remove unused lambda captures.