### PR TITLE
Fix rxcpp::observable<>::range<T>() when T is unsigned type

### DIFF
--- a/Rx/v2/src/rxcpp/sources/rx-range.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-range.hpp
@@ -86,7 +86,7 @@ struct range : public source_base<T>
                     return;
                 }
 
-                if (std::abs(state.last - state.next) < std::abs(state.step)) {
+                if (std::max(state.last, state.next) - std::min(state.last, state.next) < std::abs(state.step)) {
                     if (state.last != state.next) {
                         dest.on_next(state.last);
                     }


### PR DESCRIPTION
The following code does not compile since `std::abs` is not defined for unsigned types. Moreover, subtraction of two unsigned values may lead to unwanted behaviour.
```C++
auto a = 1u, b = 2u;
rxcpp::observable<>::range(a, b).subscribe([] {});
```
This PR fixes the issue with basic `std::max() - std::min()` approach, which is applicable for both signed and unsigned values.