### PR TITLE
Fix '-Wignored-qualifiers'

### DIFF
--- a/Rx/v2/src/rxcpp/rx-subscription.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscription.hpp
@@ -379,7 +379,7 @@ public:
 
     composite_subscription()
         : inner_type()
-        , subscription(*static_cast<const inner_type* const>(this))
+        , subscription(*static_cast<const inner_type*>(this))
     {
     }
 


### PR DESCRIPTION
Fix `-Wignored-qualifiers` in `rx-subscription.hpp`:
```
/rpmbuild/BUILD/RxCpp-4.0.0/Rx/v2/src/rxcpp/rx-subscription.hpp: In constructor 'rxcpp::composite_subscription::composite_subscription()':
/rpmbuild/BUILD/RxCpp-4.0.0/Rx/v2/src/rxcpp/rx-subscription.hpp:382:66: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
         , subscription(*static_cast<const inner_type* const>(this))
                                                                  ^
```
This is reprocible with gcc-8.0.1 on Fedora 28:

```
gcc (GCC) 8.0.1 20180324 (Red Hat 8.0.1-0.20)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```